### PR TITLE
Android: Persist config flags to preferences

### DIFF
--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/AppPreferencesExtensions.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/AppPreferencesExtensions.kt
@@ -4,9 +4,12 @@
 
 package com.algoritmico.passepartout.business.extensions
 
+import android.util.Log
+import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
@@ -14,6 +17,37 @@ import com.algoritmico.passepartout.models.AppPreferenceKey
 import com.algoritmico.passepartout.models.AppPreferences
 import com.algoritmico.passepartout.models.ConfigFlag
 import com.algoritmico.passepartout.models.ExperimentalPreferences
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
+
+//region Flows
+fun DataStore<Preferences>.appPreferences(logTag: String): Flow<AppPreferences> {
+    return data.safePreferences(logTag)
+        .map { it.toAppPreferences() }
+}
+
+fun Flow<Preferences>.appPreferences(logTag: String): Flow<AppPreferences> {
+    return safePreferences(logTag)
+        .map { it.toAppPreferences() }
+}
+
+fun DataStore<Preferences>.currentAppPreferences(logTag: String): AppPreferences {
+    return runBlocking {
+        appPreferences(logTag).first()
+    }
+}
+
+private fun Flow<Preferences>.safePreferences(logTag: String): Flow<Preferences> {
+    return catch {
+        it.throwIfCancellation()
+        Log.e(logTag, "Unable to read preferences", it)
+        emit(emptyPreferences())
+    }
+}
+//endregion
 
 //region Mapping
 val AppPreferences.Companion.default: AppPreferences

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/AppPreferencesExtensions.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/AppPreferencesExtensions.kt
@@ -10,6 +10,7 @@ import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
@@ -19,9 +20,12 @@ import com.algoritmico.passepartout.models.ConfigFlag
 import com.algoritmico.passepartout.models.ExperimentalPreferences
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.runBlocking
+
+data class LastCheckedVersionSnapshot(
+    val timestamp: Long,
+    val version: String?
+)
 
 //region Flows
 fun DataStore<Preferences>.appPreferences(logTag: String): Flow<AppPreferences> {
@@ -34,10 +38,11 @@ fun Flow<Preferences>.appPreferences(logTag: String): Flow<AppPreferences> {
         .map { it.toAppPreferences() }
 }
 
-fun DataStore<Preferences>.currentAppPreferences(logTag: String): AppPreferences {
-    return runBlocking {
-        appPreferences(logTag).first()
-    }
+fun DataStore<Preferences>.lastCheckedVersionSnapshots(
+    logTag: String
+): Flow<LastCheckedVersionSnapshot?> {
+    return appPreferences(logTag)
+        .map { it.lastCheckedVersionSnapshot() }
 }
 
 private fun Flow<Preferences>.safePreferences(logTag: String): Flow<Preferences> {
@@ -136,6 +141,11 @@ fun Preferences.toAppPreferences(): AppPreferences {
     )
 }
 
+private fun AppPreferences.lastCheckedVersionSnapshot(): LastCheckedVersionSnapshot? {
+    val timestamp = lastCheckedVersionTimestamp ?: return null
+    return LastCheckedVersionSnapshot(timestamp, lastCheckedVersion)
+}
+
 private inline fun <reified T> String.decodePreference(): T? {
     return runCatching {
         JSON.decode<T>(this)
@@ -148,6 +158,20 @@ fun MutablePreferences.toggleDnsFallback(): Boolean {
     val newValue = !(this[K.DNS_FALLS_BACK] ?: AppPreferences.default.dnsFallsBack)
     this[K.DNS_FALLS_BACK] = newValue
     return newValue
+}
+
+suspend fun DataStore<Preferences>.updateLastCheckedVersion(
+    timestamp: Long,
+    version: String?
+) {
+    edit {
+        val current = it.toAppPreferences()
+        val newValue = current.copy(
+            lastCheckedVersionTimestamp = timestamp,
+            lastCheckedVersion = version ?: current.lastCheckedVersion
+        )
+        it.update(LAST_CHECKED_VERSION_FIELDS, newValue)
+    }
 }
 
 fun MutablePreferences.updateExperimentalPreferences(
@@ -241,6 +265,11 @@ private object K {
     val RELAXED_VERIFICATION = booleanPreferencesKey(AppPreferenceKey.relaxedVerification.name)
     val SKIPS_PURCHASES = booleanPreferencesKey(AppPreferenceKey.skipsPurchases.name)
 }
+
+private val LAST_CHECKED_VERSION_FIELDS = listOf(
+    AppPreferenceKey.lastCheckedVersion,
+    AppPreferenceKey.lastCheckedVersionDate
+)
 //endregion
 
 //region Experimental

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/AppPreferencesExtensions.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/AppPreferencesExtensions.kt
@@ -4,14 +4,215 @@
 
 package com.algoritmico.passepartout.business.extensions
 
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
 import com.algoritmico.passepartout.models.AppPreferenceKey
 import com.algoritmico.passepartout.models.AppPreferences
 import com.algoritmico.passepartout.models.ConfigFlag
 import com.algoritmico.passepartout.models.ExperimentalPreferences
 
+//region Mapping
+val AppPreferences.Companion.default: AppPreferences
+    get() = AppPreferences(
+        configFlags = listOf(),
+        dnsFallsBack = true,
+        experimental = ExperimentalPreferences(listOf(), listOf()),
+        extensiveLogging = false,
+        logsPrivateData = false,
+        newProfileEncoding = false,
+        relaxedVerification = false,
+        skipsPurchases = false
+    )
+
+fun AppPreferences.update(fields: Collection<AppPreferenceKey>, new: AppPreferences): AppPreferences {
+    var updated = this
+    fields.forEach {
+        updated = when (it) {
+            AppPreferenceKey.deviceId -> updated.copy(
+                deviceId = new.deviceId
+            )
+            AppPreferenceKey.configFlags -> updated.copy(
+                configFlags = new.configFlags
+            )
+            AppPreferenceKey.dnsFallsBack -> updated.copy(
+                dnsFallsBack = new.dnsFallsBack
+            )
+            AppPreferenceKey.experimental -> updated.copy(
+                experimental = new.experimental
+            )
+            AppPreferenceKey.extensiveLogging -> updated.copy(
+                extensiveLogging = new.extensiveLogging
+            )
+            AppPreferenceKey.lastCheckedVersion -> updated.copy(
+                lastCheckedVersion = new.lastCheckedVersion
+            )
+            AppPreferenceKey.lastCheckedVersionDate -> updated.copy(
+                lastCheckedVersionTimestamp = new.lastCheckedVersionTimestamp
+            )
+            AppPreferenceKey.lastUsedProfileId -> updated.copy(
+                lastUsedProfileUUID = new.lastUsedProfileUUID
+            )
+            AppPreferenceKey.logsPrivateData -> updated.copy(
+                logsPrivateData = new.logsPrivateData
+            )
+            AppPreferenceKey.newProfileEncoding -> updated.copy(
+                newProfileEncoding = new.newProfileEncoding
+            )
+            AppPreferenceKey.relaxedVerification -> updated.copy(
+                relaxedVerification = new.relaxedVerification
+            )
+            AppPreferenceKey.skipsPurchases -> updated.copy(
+                skipsPurchases = new.skipsPurchases
+            )
+        }
+    }
+    return updated
+}
+
+fun Preferences.toAppPreferences(): AppPreferences {
+    val default = AppPreferences.default
+    return AppPreferences(
+        configFlags = this[K.CONFIG_FLAGS]
+            ?.mapNotNull { ConfigFlag.decode(it) }
+            ?.toMutableList()
+            ?: default.configFlags,
+        dnsFallsBack = this[K.DNS_FALLS_BACK]
+            ?: default.dnsFallsBack,
+        experimental = this[K.EXPERIMENTAL]
+            ?.decodePreference()
+            ?: default.experimental,
+        extensiveLogging = this[K.EXTENSIVE_LOGGING]
+            ?: default.extensiveLogging,
+        logsPrivateData = this[K.LOGS_PRIVATE_DATA]
+            ?: default.logsPrivateData,
+        newProfileEncoding = this[K.NEW_PROFILE_ENCODING]
+            ?: default.newProfileEncoding,
+        relaxedVerification = this[K.RELAXED_VERIFICATION]
+            ?: default.relaxedVerification,
+        skipsPurchases = this[K.SKIPS_PURCHASES]
+            ?: default.skipsPurchases,
+        deviceId = this[K.DEVICE_ID],
+        lastCheckedVersionTimestamp = this[K.LAST_CHECKED_VERSION_DATE],
+        lastCheckedVersion = this[K.LAST_CHECKED_VERSION],
+        lastUsedProfileUUID = this[K.LAST_USED_PROFILE_ID]
+    )
+}
+
+private inline fun <reified T> String.decodePreference(): T? {
+    return runCatching {
+        JSON.decode<T>(this)
+    }.getOrNull()
+}
+//endregion
+
+//region Store
+fun MutablePreferences.toggleDnsFallback(): Boolean {
+    val newValue = !(this[K.DNS_FALLS_BACK] ?: AppPreferences.default.dnsFallsBack)
+    this[K.DNS_FALLS_BACK] = newValue
+    return newValue
+}
+
+fun MutablePreferences.updateExperimentalPreferences(
+    current: ExperimentalPreferences,
+    transform: (ExperimentalPreferences) -> ExperimentalPreferences
+): ExperimentalPreferences {
+    val newValue = transform(
+        this[K.EXPERIMENTAL]?.decodePreference<ExperimentalPreferences>()
+            ?: current
+    )
+    this[K.EXPERIMENTAL] = JSON.encode(newValue)
+    return newValue
+}
+
+fun MutablePreferences.update(fields: Collection<AppPreferenceKey>, new: AppPreferences) {
+    fields.forEach {
+        when (it) {
+            AppPreferenceKey.deviceId ->
+                setOrRemove(
+                    K.DEVICE_ID,
+                    new.deviceId
+                )
+
+            AppPreferenceKey.configFlags ->
+                this[K.CONFIG_FLAGS] = new.configFlags.map {
+                    flags -> flags.value
+                }.toSet()
+
+            AppPreferenceKey.dnsFallsBack ->
+                this[K.DNS_FALLS_BACK] = new.dnsFallsBack
+
+            AppPreferenceKey.experimental ->
+                this[K.EXPERIMENTAL] = JSON.encode(new.experimental)
+
+            AppPreferenceKey.extensiveLogging ->
+                this[K.EXTENSIVE_LOGGING] = new.extensiveLogging
+
+            AppPreferenceKey.lastCheckedVersion ->
+                setOrRemove(
+                    K.LAST_CHECKED_VERSION,
+                    new.lastCheckedVersion
+                )
+
+            AppPreferenceKey.lastCheckedVersionDate ->
+                setOrRemove(
+                    K.LAST_CHECKED_VERSION_DATE,
+                    new.lastCheckedVersionTimestamp
+                )
+
+            AppPreferenceKey.lastUsedProfileId ->
+                setOrRemove(
+                    K.LAST_USED_PROFILE_ID,
+                    new.lastUsedProfileUUID
+                )
+
+            AppPreferenceKey.logsPrivateData ->
+                this[K.LOGS_PRIVATE_DATA] = new.logsPrivateData
+
+            AppPreferenceKey.newProfileEncoding ->
+                this[K.NEW_PROFILE_ENCODING] = new.newProfileEncoding
+
+            AppPreferenceKey.relaxedVerification ->
+                this[K.RELAXED_VERIFICATION] = new.relaxedVerification
+
+            AppPreferenceKey.skipsPurchases ->
+                this[K.SKIPS_PURCHASES] = new.skipsPurchases
+        }
+    }
+}
+
+private fun <T> MutablePreferences.setOrRemove(key: Preferences.Key<T>, value: T?) {
+    if (value == null) {
+        remove(key)
+        return
+    }
+    this[key] = value
+}
+
+private object K {
+    val CONFIG_FLAGS = stringSetPreferencesKey(AppPreferenceKey.configFlags.name)
+    val DEVICE_ID = stringPreferencesKey(AppPreferenceKey.deviceId.name)
+    val DNS_FALLS_BACK = booleanPreferencesKey(AppPreferenceKey.dnsFallsBack.name)
+    val EXPERIMENTAL = stringPreferencesKey(AppPreferenceKey.experimental.name)
+    val EXTENSIVE_LOGGING = booleanPreferencesKey(AppPreferenceKey.extensiveLogging.name)
+    val LAST_CHECKED_VERSION = stringPreferencesKey(AppPreferenceKey.lastCheckedVersion.name)
+    val LAST_CHECKED_VERSION_DATE =
+        longPreferencesKey(AppPreferenceKey.lastCheckedVersionDate.name)
+    val LAST_USED_PROFILE_ID = stringPreferencesKey(AppPreferenceKey.lastUsedProfileId.name)
+    val LOGS_PRIVATE_DATA = booleanPreferencesKey(AppPreferenceKey.logsPrivateData.name)
+    val NEW_PROFILE_ENCODING = booleanPreferencesKey(AppPreferenceKey.newProfileEncoding.name)
+    val RELAXED_VERIFICATION = booleanPreferencesKey(AppPreferenceKey.relaxedVerification.name)
+    val SKIPS_PURCHASES = booleanPreferencesKey(AppPreferenceKey.skipsPurchases.name)
+}
+//endregion
+
+//region Experimental
 fun AppPreferences.isFlagEnabled(flag: ConfigFlag): Boolean {
     return (configFlags.contains(flag) || experimental.enabledConfigFlags.contains(flag)) &&
-        !experimental.ignoredConfigFlags.contains(flag)
+            !experimental.ignoredConfigFlags.contains(flag)
 }
 
 fun ExperimentalPreferences.isAllowed(flag: ConfigFlag): Boolean {
@@ -64,63 +265,4 @@ private fun List<ConfigFlag>.adding(flag: ConfigFlag): List<ConfigFlag> {
 private fun List<ConfigFlag>.removing(flag: ConfigFlag): List<ConfigFlag> {
     return filterNot { it == flag }
 }
-
-val AppPreferences.Companion.default: AppPreferences
-    get() = AppPreferences(
-        configFlags = listOf(),
-        dnsFallsBack = true,
-        experimental = ExperimentalPreferences(listOf(), listOf()),
-        extensiveLogging = false,
-        logsPrivateData = false,
-        newProfileEncoding = false,
-        relaxedVerification = false,
-        skipsPurchases = false
-    )
-
-fun AppPreferences.update(
-    new: AppPreferences,
-    fields: List<AppPreferenceKey>
-): AppPreferences {
-    var updated = this
-    fields.forEach {
-        updated = when (it) {
-            AppPreferenceKey.deviceId -> updated.copy(
-                deviceId = new.deviceId
-            )
-            AppPreferenceKey.configFlags -> updated.copy(
-                configFlags = new.configFlags
-            )
-            AppPreferenceKey.dnsFallsBack -> updated.copy(
-                dnsFallsBack = new.dnsFallsBack
-            )
-            AppPreferenceKey.experimental -> updated.copy(
-                experimental = new.experimental
-            )
-            AppPreferenceKey.extensiveLogging -> updated.copy(
-                extensiveLogging = new.extensiveLogging
-            )
-            AppPreferenceKey.lastCheckedVersion -> updated.copy(
-                lastCheckedVersion = new.lastCheckedVersion
-            )
-            AppPreferenceKey.lastCheckedVersionDate -> updated.copy(
-                lastCheckedVersionTimestamp = new.lastCheckedVersionTimestamp
-            )
-            AppPreferenceKey.lastUsedProfileId -> updated.copy(
-                lastUsedProfileUUID = new.lastUsedProfileUUID
-            )
-            AppPreferenceKey.logsPrivateData -> updated.copy(
-                logsPrivateData = new.logsPrivateData
-            )
-            AppPreferenceKey.newProfileEncoding -> updated.copy(
-                newProfileEncoding = new.newProfileEncoding
-            )
-            AppPreferenceKey.relaxedVerification -> updated.copy(
-                relaxedVerification = new.relaxedVerification
-            )
-            AppPreferenceKey.skipsPurchases -> updated.copy(
-                skipsPurchases = new.skipsPurchases
-            )
-        }
-    }
-    return updated
-}
+//endregion

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/DataHelpers.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/DataHelpers.kt
@@ -12,7 +12,7 @@ data class DataSpeed(
     val sent: Long
 ) {
     companion object {
-        val ZERO = DataSpeed(received = 0L, sent = 0L)
+        val zero = DataSpeed(received = 0L, sent = 0L)
     }
 }
 
@@ -28,7 +28,7 @@ fun DataCount.speedSince(
     elapsedRealtimeMillis: Long
 ): DataSpeed {
     if (previous == null || previous.id != id) {
-        return DataSpeed.ZERO
+        return DataSpeed.zero
     }
     val elapsedMillis = elapsedRealtimeMillis - previous.elapsedRealtimeMillis
     return DataSpeed(

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/SemanticVersionExtensions.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/SemanticVersionExtensions.kt
@@ -8,3 +8,17 @@ import com.algoritmico.passepartout.models.SemanticVersion
 
 val SemanticVersion.versionString: String
     get() = "$major.$minor.$patch"
+
+val SemanticVersion.Companion.max: SemanticVersion
+    get() = SemanticVersion(255, 255, 255)
+
+fun String.toSemanticVersionOrNull(): SemanticVersion? {
+    return runCatching {
+        val parts = split(".")
+        require(parts.size == 3)
+        val major = parts[0].toInt()
+        val minor = parts[1].toInt()
+        val patch = parts[2].toInt()
+        SemanticVersion(major, minor, patch)
+    }.getOrNull()
+}

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/SemanticVersionExtensions.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/SemanticVersionExtensions.kt
@@ -22,3 +22,11 @@ fun String.toSemanticVersionOrNull(): SemanticVersion? {
         SemanticVersion(major, minor, patch)
     }.getOrNull()
 }
+
+operator fun SemanticVersion.compareTo(other: SemanticVersion): Int {
+    return encodedValue().compareTo(other.encodedValue())
+}
+
+private fun SemanticVersion.encodedValue(): Int {
+    return ((major and 0xff) shl 16) + ((minor and 0xff) shl 8) + (patch and 0xff)
+}

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ConfigManager.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ConfigManager.kt
@@ -6,7 +6,6 @@ package com.algoritmico.passepartout.business.managers
 
 import android.util.Log
 import com.algoritmico.passepartout.business.extensions.JSON
-import com.algoritmico.passepartout.business.extensions.throwIfCancellation
 import com.algoritmico.passepartout.context.newEventFlow
 import com.algoritmico.passepartout.models.ConfigBundleConfig
 import com.algoritmico.passepartout.models.ConfigEventRefresh
@@ -56,11 +55,11 @@ class ConfigManager(
         }.also {
             refreshMutex.unlock()
         }.onFailure {
-            it.throwIfCancellation()
             when (it) {
                 is ConfigManagerException.RateLimit -> Log.d(logTag, "Config: TTL")
                 else -> Log.e(logTag, "Unable to refresh config flags", it)
             }
+            throw it
         }
     }
 

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ConfigManager.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ConfigManager.kt
@@ -6,6 +6,7 @@ package com.algoritmico.passepartout.business.managers
 
 import android.util.Log
 import com.algoritmico.passepartout.business.extensions.JSON
+import com.algoritmico.passepartout.business.extensions.throwIfCancellation
 import com.algoritmico.passepartout.context.newEventFlow
 import com.algoritmico.passepartout.models.ConfigBundleConfig
 import com.algoritmico.passepartout.models.ConfigEventRefresh
@@ -38,11 +39,11 @@ class ConfigManager(
     private val _events = newEventFlow()
     val events: SharedFlow<Event> = _events.asSharedFlow()
 
-    suspend fun refreshBundle() {
+    suspend fun refreshBundle(): Boolean {
         if (!refreshMutex.tryLock()) {
-            return
+            return false
         }
-        runCatching {
+        return runCatching {
             Log.d(logTag, "Config: refreshing bundle...")
             val newBundle = strategy.bundle()
             val event = synchronized(bundleLock) {
@@ -52,14 +53,21 @@ class ConfigManager(
             _events.emit(event)
             Log.i(logTag, "Config: active flags = ${event.flags}")
             Log.d(logTag, "Config: $newBundle")
+            true
         }.also {
             refreshMutex.unlock()
-        }.onFailure {
+        }.getOrElse {
+            it.throwIfCancellation()
             when (it) {
-                is ConfigManagerException.RateLimit -> Log.d(logTag, "Config: TTL")
-                else -> Log.e(logTag, "Unable to refresh config flags", it)
+                is ConfigManagerException.RateLimit -> {
+                    Log.d(logTag, "Config: TTL")
+                    false
+                }
+                else -> {
+                    Log.e(logTag, "Unable to refresh config flags", it)
+                    throw it
+                }
             }
-            throw it
         }
     }
 

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ConfigManager.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ConfigManager.kt
@@ -20,6 +20,7 @@ import kotlinx.serialization.json.JsonObject
 
 interface ConfigManagerStrategy {
     suspend fun bundle(): ConfigBundle
+    fun resetTTL()
 }
 
 sealed class ConfigManagerException: Exception() {
@@ -28,7 +29,7 @@ sealed class ConfigManagerException: Exception() {
 
 class ConfigManager(
     private val logTag: String,
-    private val strategy: ConfigManagerStrategy? = null,
+    private val strategy: ConfigManagerStrategy,
     private val buildNumber: Int = Int.MAX_VALUE
 ) {
     private val refreshMutex = Mutex()
@@ -39,7 +40,6 @@ class ConfigManager(
     val events: SharedFlow<Event> = _events.asSharedFlow()
 
     suspend fun refreshBundle() {
-        val strategy = strategy ?: return
         if (!refreshMutex.tryLock()) {
             return
         }
@@ -62,6 +62,10 @@ class ConfigManager(
                 else -> Log.e(logTag, "Unable to refresh config flags", it)
             }
         }
+    }
+
+    fun resetTTL() {
+        strategy.resetTTL()
     }
 
     fun isActive(flag: ConfigFlag): Boolean {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/VersionChecker.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/VersionChecker.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import com.algoritmico.passepartout.business.extensions.currentAppPreferences
 import com.algoritmico.passepartout.business.extensions.throwIfCancellation
 import com.algoritmico.passepartout.business.extensions.toAppPreferences
 import com.algoritmico.passepartout.business.extensions.update
@@ -21,8 +22,6 @@ import com.algoritmico.passepartout.models.VersionEventNew
 import com.algoritmico.passepartout.models.VersionRelease
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 
 data class VersionCheckerSnapshot(
@@ -127,9 +126,7 @@ class VersionChecker(
     }
 
     private fun onLastSnapshot(): VersionCheckerSnapshot? {
-        val snapshot = runBlocking {
-            store.data.first().toAppPreferences()
-        }
+        val snapshot = store.currentAppPreferences(logTag)
         val timestamp = snapshot.lastCheckedVersionTimestamp ?: return null
         return VersionCheckerSnapshot(timestamp, snapshot.lastCheckedVersion)
     }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/VersionChecker.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/VersionChecker.kt
@@ -7,6 +7,7 @@ package com.algoritmico.passepartout.business.managers
 import android.util.Log
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import com.algoritmico.passepartout.business.extensions.LastCheckedVersionSnapshot
 import com.algoritmico.passepartout.business.extensions.lastCheckedVersionSnapshots
 import com.algoritmico.passepartout.business.extensions.max
 import com.algoritmico.passepartout.business.extensions.throwIfCancellation
@@ -26,6 +27,8 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.sync.Mutex
 import java.io.Closeable
@@ -53,14 +56,15 @@ class VersionChecker(
         coroutineScope.coroutineContext + SupervisorJob(coroutineScope.coroutineContext[Job])
     )
     private val snapshots = store.lastCheckedVersionSnapshots(logTag)
-        .stateIn(scope, SharingStarted.Eagerly, null)
+        .map { VersionSnapshotState.Ready(it) }
+        .stateIn(scope, SharingStarted.Eagerly, VersionSnapshotState.Loading)
     private val currentVersion = currentVersion.toSemanticVersionOrNull() ?: SemanticVersion.max
     private val _events = newEventFlow()
     val events: SharedFlow<Event> = _events.asSharedFlow()
 
     val latestRelease: VersionRelease?
         get() {
-            val latestVersionDescription = snapshots.value?.version ?: return null
+            val latestVersionDescription = currentSnapshot()?.version ?: return null
             val latestVersion = latestVersionDescription.toSemanticVersionOrNull() ?: return null
             return latestVersion.release()
         }
@@ -73,7 +77,7 @@ class VersionChecker(
             val now = System.currentTimeMillis()
             var didCheck = false
             val checkedRelease = runCatching {
-                val lastCheckedTimestamp = snapshots.value?.timestamp
+                val lastCheckedTimestamp = readySnapshot()?.timestamp
                 Log.d(logTag, "Version: checking for updates...")
                 val fetchedLatestVersion = strategy.latestVersion(lastCheckedTimestamp)
                 saveVersion(now, fetchedLatestVersion.versionString)
@@ -121,12 +125,34 @@ class VersionChecker(
         store.updateLastCheckedVersion(timestamp, version)
     }
 
+    private fun currentSnapshot(): LastCheckedVersionSnapshot? {
+        return when (val state = snapshots.value) {
+            is VersionSnapshotState.Ready -> state.snapshot
+            VersionSnapshotState.Loading -> null
+        }
+    }
+
+    private suspend fun readySnapshot(): LastCheckedVersionSnapshot? {
+        return when (val state = snapshots.value) {
+            is VersionSnapshotState.Ready -> state.snapshot
+            VersionSnapshotState.Loading -> {
+                (snapshots.first { it is VersionSnapshotState.Ready } as VersionSnapshotState.Ready)
+                    .snapshot
+            }
+        }
+    }
+
     private fun SemanticVersion.release(): VersionRelease? {
         if (this <= currentVersion) {
             return null
         }
         return VersionRelease(version = this, url = downloadURL)
     }
+}
+
+private sealed class VersionSnapshotState {
+    data object Loading : VersionSnapshotState()
+    data class Ready(val snapshot: LastCheckedVersionSnapshot?) : VersionSnapshotState()
 }
 
 private operator fun SemanticVersion.compareTo(other: SemanticVersion): Int {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/VersionChecker.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/VersionChecker.kt
@@ -7,27 +7,28 @@ package com.algoritmico.passepartout.business.managers
 import android.util.Log
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.edit
-import com.algoritmico.passepartout.business.extensions.currentAppPreferences
+import com.algoritmico.passepartout.business.extensions.lastCheckedVersionSnapshots
+import com.algoritmico.passepartout.business.extensions.max
 import com.algoritmico.passepartout.business.extensions.throwIfCancellation
-import com.algoritmico.passepartout.business.extensions.toAppPreferences
-import com.algoritmico.passepartout.business.extensions.update
+import com.algoritmico.passepartout.business.extensions.toSemanticVersionOrNull
+import com.algoritmico.passepartout.business.extensions.updateLastCheckedVersion
 import com.algoritmico.passepartout.business.extensions.versionString
 import com.algoritmico.passepartout.context.newEventFlow
-import com.algoritmico.passepartout.models.AppPreferenceKey
 import com.algoritmico.passepartout.models.ChangelogEntry
 import com.algoritmico.passepartout.models.Event
 import com.algoritmico.passepartout.models.SemanticVersion
 import com.algoritmico.passepartout.models.VersionEventNew
 import com.algoritmico.passepartout.models.VersionRelease
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.sync.Mutex
-
-data class VersionCheckerSnapshot(
-    val timestamp: Long,
-    val version: String?
-)
+import java.io.Closeable
 
 interface VersionCheckerStrategy {
     suspend fun latestVersion(sinceTimestamp: Long?): SemanticVersion
@@ -42,67 +43,69 @@ sealed class VersionCheckerException: Exception() {
 class VersionChecker(
     private val logTag: String,
     private val store: DataStore<Preferences>,
+    coroutineScope: CoroutineScope,
     private val strategy: VersionCheckerStrategy = DummyVersionCheckerStrategy(),
     currentVersion: String = "255.255.255",
     private val downloadURL: String = "http://"
-) {
-    private val currentVersion = currentVersion.toSemanticVersionOrNull() ?: SemanticVersion(
-        0,
-        0,
-        0
+) : Closeable {
+    private val mutex = Mutex()
+    private val scope = CoroutineScope(
+        coroutineScope.coroutineContext + SupervisorJob(coroutineScope.coroutineContext[Job])
     )
-    private val checkMutex = Mutex()
-
+    private val snapshots = store.lastCheckedVersionSnapshots(logTag)
+        .stateIn(scope, SharingStarted.Eagerly, null)
+    private val currentVersion = currentVersion.toSemanticVersionOrNull() ?: SemanticVersion.max
     private val _events = newEventFlow()
     val events: SharedFlow<Event> = _events.asSharedFlow()
 
     val latestRelease: VersionRelease?
         get() {
-            val latestVersionDescription = onLastSnapshot()?.version ?: return null
+            val latestVersionDescription = snapshots.value?.version ?: return null
             val latestVersion = latestVersionDescription.toSemanticVersionOrNull() ?: return null
-            if (latestVersion <= currentVersion) {
-                return null
-            }
-            return VersionRelease(version = latestVersion, url = downloadURL)
+            return latestVersion.release()
         }
 
     suspend fun checkLatestRelease() {
-        if (!checkMutex.tryLock()) {
+        if (!mutex.tryLock()) {
             return
         }
         runCatching {
             val now = System.currentTimeMillis()
-            runCatching {
-                val lastCheckedTimestamp = onLastSnapshot()?.timestamp
+            var didCheck = false
+            val checkedRelease = runCatching {
+                val lastCheckedTimestamp = snapshots.value?.timestamp
                 Log.d(logTag, "Version: checking for updates...")
                 val fetchedLatestVersion = strategy.latestVersion(lastCheckedTimestamp)
-                onSaveVersion(now, fetchedLatestVersion.versionString)
+                saveVersion(now, fetchedLatestVersion.versionString)
+                didCheck = true
                 Log.i(
                     logTag,
                     "Version: ${fetchedLatestVersion.versionString} > " +
                         "${currentVersion.versionString} = ${fetchedLatestVersion > currentVersion}"
                 )
-            }.onFailure {
+                fetchedLatestVersion.release()
+            }.getOrElse {
                 it.throwIfCancellation()
                 when (it) {
                     is VersionCheckerException.RateLimit -> Log.d(logTag, "Version: rate limit")
                     is VersionCheckerException.UnexpectedResponse -> {
-                        onSaveVersion(now, null)
+                        saveVersion(now, null)
                         Log.e(logTag, "Unable to check version", it)
                     }
                     else -> Log.e(logTag, "Unable to check version", it)
                 }
+                null
             }
 
-            val latestRelease = latestRelease
+            val latestRelease = if (didCheck) checkedRelease else latestRelease
             if (latestRelease == null) {
                 Log.d(logTag, "Version: current is latest version")
-                return
+            } else {
+                Log.i(logTag, "Version: new version available at ${latestRelease.url}")
+                _events.emit(VersionEventNew(release = latestRelease))
             }
-            Log.i(logTag, "Version: new version available at ${latestRelease.url}")
-            _events.emit(VersionEventNew(release = latestRelease))
         }.also {
-            checkMutex.unlock()
+            mutex.unlock()
         }.getOrThrow()
     }
 
@@ -110,37 +113,20 @@ class VersionChecker(
         return strategy.fetchChangelog(version)
     }
 
-    private suspend fun onSaveVersion(timestamp: Long, version: String?) {
-        val fields = listOf(
-            AppPreferenceKey.lastCheckedVersion,
-            AppPreferenceKey.lastCheckedVersionDate
-        )
-        store.edit {
-            val current = it.toAppPreferences()
-            val newValue = current.copy(
-                lastCheckedVersionTimestamp = timestamp,
-                lastCheckedVersion = version ?: current.lastCheckedVersion
-            )
-            it.update(fields, newValue)
+    override fun close() {
+        scope.cancel()
+    }
+
+    private suspend fun saveVersion(timestamp: Long, version: String?) {
+        store.updateLastCheckedVersion(timestamp, version)
+    }
+
+    private fun SemanticVersion.release(): VersionRelease? {
+        if (this <= currentVersion) {
+            return null
         }
+        return VersionRelease(version = this, url = downloadURL)
     }
-
-    private fun onLastSnapshot(): VersionCheckerSnapshot? {
-        val snapshot = store.currentAppPreferences(logTag)
-        val timestamp = snapshot.lastCheckedVersionTimestamp ?: return null
-        return VersionCheckerSnapshot(timestamp, snapshot.lastCheckedVersion)
-    }
-}
-
-fun String.toSemanticVersionOrNull(): SemanticVersion? {
-    return runCatching {
-        val parts = split(".")
-        require(parts.size == 3)
-        val major = parts[0].toInt()
-        val minor = parts[1].toInt()
-        val patch = parts[2].toInt()
-        SemanticVersion(major, minor, patch)
-    }.getOrNull()
 }
 
 private operator fun SemanticVersion.compareTo(other: SemanticVersion): Int {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/VersionChecker.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/VersionChecker.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import com.algoritmico.passepartout.business.extensions.LastCheckedVersionSnapshot
+import com.algoritmico.passepartout.business.extensions.compareTo
 import com.algoritmico.passepartout.business.extensions.lastCheckedVersionSnapshots
 import com.algoritmico.passepartout.business.extensions.max
 import com.algoritmico.passepartout.business.extensions.throwIfCancellation
@@ -74,21 +75,19 @@ class VersionChecker(
             return
         }
         runCatching {
-            val latestRelease = newReleaseOrNull() ?: latestRelease
             val now = System.currentTimeMillis()
-            val result = runCatching {
+            val release = runCatching {
                 newReleaseOrNull(now)
             }.onFailure {
                 handleVersionCheckFailure(now, it)
-            }
-            val latestRelease = result.getOrElse {
+            }.getOrElse {
                 latestRelease
             }
-            if (latestRelease == null) {
+            if (release == null) {
                 Log.d(logTag, "Version: current is latest version")
             } else {
-                Log.i(logTag, "Version: new version available at ${latestRelease.url}")
-                _events.emit(VersionEventNew(release = latestRelease))
+                Log.i(logTag, "Version: new version available at ${release.url}")
+                _events.emit(VersionEventNew(release = release))
             }
         }.also {
             mutex.unlock()
@@ -160,14 +159,6 @@ class VersionChecker(
 private sealed class VersionSnapshotState {
     data object Loading : VersionSnapshotState()
     data class Ready(val snapshot: LastCheckedVersionSnapshot?) : VersionSnapshotState()
-}
-
-private operator fun SemanticVersion.compareTo(other: SemanticVersion): Int {
-    return encodedValue().compareTo(other.encodedValue())
-}
-
-private fun SemanticVersion.encodedValue(): Int {
-    return ((major and 0xff) shl 16) + ((minor and 0xff) shl 8) + (patch and 0xff)
 }
 
 private class DummyVersionCheckerStrategy : VersionCheckerStrategy {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/VersionChecker.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/VersionChecker.kt
@@ -5,9 +5,15 @@
 package com.algoritmico.passepartout.business.managers
 
 import android.util.Log
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
 import com.algoritmico.passepartout.business.extensions.throwIfCancellation
+import com.algoritmico.passepartout.business.extensions.toAppPreferences
+import com.algoritmico.passepartout.business.extensions.update
 import com.algoritmico.passepartout.business.extensions.versionString
 import com.algoritmico.passepartout.context.newEventFlow
+import com.algoritmico.passepartout.models.AppPreferenceKey
 import com.algoritmico.passepartout.models.ChangelogEntry
 import com.algoritmico.passepartout.models.Event
 import com.algoritmico.passepartout.models.SemanticVersion
@@ -15,6 +21,8 @@ import com.algoritmico.passepartout.models.VersionEventNew
 import com.algoritmico.passepartout.models.VersionRelease
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 
 data class VersionCheckerSnapshot(
@@ -24,9 +32,7 @@ data class VersionCheckerSnapshot(
 
 interface VersionCheckerStrategy {
     suspend fun latestVersion(sinceTimestamp: Long?): SemanticVersion
-    suspend fun saveVersion(timestamp: Long, version: String?)
     suspend fun fetchChangelog(version: String): List<ChangelogEntry>
-    val lastSnapshot: VersionCheckerSnapshot?
 }
 
 sealed class VersionCheckerException: Exception() {
@@ -36,6 +42,7 @@ sealed class VersionCheckerException: Exception() {
 
 class VersionChecker(
     private val logTag: String,
+    private val store: DataStore<Preferences>,
     private val strategy: VersionCheckerStrategy = DummyVersionCheckerStrategy(),
     currentVersion: String = "255.255.255",
     private val downloadURL: String = "http://"
@@ -52,7 +59,7 @@ class VersionChecker(
 
     val latestRelease: VersionRelease?
         get() {
-            val latestVersionDescription = strategy.lastSnapshot?.version ?: return null
+            val latestVersionDescription = onLastSnapshot()?.version ?: return null
             val latestVersion = latestVersionDescription.toSemanticVersionOrNull() ?: return null
             if (latestVersion <= currentVersion) {
                 return null
@@ -67,10 +74,10 @@ class VersionChecker(
         runCatching {
             val now = System.currentTimeMillis()
             runCatching {
-                val lastCheckedTimestamp = strategy.lastSnapshot?.timestamp
+                val lastCheckedTimestamp = onLastSnapshot()?.timestamp
                 Log.d(logTag, "Version: checking for updates...")
                 val fetchedLatestVersion = strategy.latestVersion(lastCheckedTimestamp)
-                strategy.saveVersion(now, fetchedLatestVersion.versionString)
+                onSaveVersion(now, fetchedLatestVersion.versionString)
                 Log.i(
                     logTag,
                     "Version: ${fetchedLatestVersion.versionString} > " +
@@ -81,7 +88,7 @@ class VersionChecker(
                 when (it) {
                     is VersionCheckerException.RateLimit -> Log.d(logTag, "Version: rate limit")
                     is VersionCheckerException.UnexpectedResponse -> {
-                        strategy.saveVersion(now, null)
+                        onSaveVersion(now, null)
                         Log.e(logTag, "Unable to check version", it)
                     }
                     else -> Log.e(logTag, "Unable to check version", it)
@@ -102,6 +109,29 @@ class VersionChecker(
 
     suspend fun fetchChangelog(version: String): List<ChangelogEntry> {
         return strategy.fetchChangelog(version)
+    }
+
+    private suspend fun onSaveVersion(timestamp: Long, version: String?) {
+        val fields = listOf(
+            AppPreferenceKey.lastCheckedVersion,
+            AppPreferenceKey.lastCheckedVersionDate
+        )
+        store.edit {
+            val current = it.toAppPreferences()
+            val newValue = current.copy(
+                lastCheckedVersionTimestamp = timestamp,
+                lastCheckedVersion = version ?: current.lastCheckedVersion
+            )
+            it.update(fields, newValue)
+        }
+    }
+
+    private fun onLastSnapshot(): VersionCheckerSnapshot? {
+        val snapshot = runBlocking {
+            store.data.first().toAppPreferences()
+        }
+        val timestamp = snapshot.lastCheckedVersionTimestamp ?: return null
+        return VersionCheckerSnapshot(timestamp, snapshot.lastCheckedVersion)
     }
 }
 
@@ -129,13 +159,7 @@ private class DummyVersionCheckerStrategy : VersionCheckerStrategy {
         return SemanticVersion(255, 255, 255)
     }
 
-    override suspend fun saveVersion(timestamp: Long, version: String?) {
-    }
-
     override suspend fun fetchChangelog(version: String): List<ChangelogEntry> {
         return emptyList()
     }
-
-    override val lastSnapshot: VersionCheckerSnapshot?
-        get() = null
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/VersionChecker.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/VersionChecker.kt
@@ -74,34 +74,16 @@ class VersionChecker(
             return
         }
         runCatching {
+            val latestRelease = newReleaseOrNull() ?: latestRelease
             val now = System.currentTimeMillis()
-            var didCheck = false
-            val checkedRelease = runCatching {
-                val lastCheckedTimestamp = readySnapshot()?.timestamp
-                Log.d(logTag, "Version: checking for updates...")
-                val fetchedLatestVersion = strategy.latestVersion(lastCheckedTimestamp)
-                saveVersion(now, fetchedLatestVersion.versionString)
-                didCheck = true
-                Log.i(
-                    logTag,
-                    "Version: ${fetchedLatestVersion.versionString} > " +
-                        "${currentVersion.versionString} = ${fetchedLatestVersion > currentVersion}"
-                )
-                fetchedLatestVersion.release()
-            }.getOrElse {
-                it.throwIfCancellation()
-                when (it) {
-                    is VersionCheckerException.RateLimit -> Log.d(logTag, "Version: rate limit")
-                    is VersionCheckerException.UnexpectedResponse -> {
-                        saveVersion(now, null)
-                        Log.e(logTag, "Unable to check version", it)
-                    }
-                    else -> Log.e(logTag, "Unable to check version", it)
-                }
-                null
+            val result = runCatching {
+                newReleaseOrNull(now)
+            }.onFailure {
+                handleVersionCheckFailure(now, it)
             }
-
-            val latestRelease = if (didCheck) checkedRelease else latestRelease
+            val latestRelease = result.getOrElse {
+                latestRelease
+            }
             if (latestRelease == null) {
                 Log.d(logTag, "Version: current is latest version")
             } else {
@@ -121,6 +103,31 @@ class VersionChecker(
         scope.cancel()
     }
 
+    private suspend fun newReleaseOrNull(timestamp: Long): VersionRelease? {
+        val lastCheckedTimestamp = waitForSnapshot()?.timestamp
+        Log.d(logTag, "Version: checking for updates...")
+        val fetchedLatestVersion = strategy.latestVersion(lastCheckedTimestamp)
+        saveVersion(timestamp, fetchedLatestVersion.versionString)
+        Log.i(
+            logTag,
+            "Version: ${fetchedLatestVersion.versionString} > " +
+                    "${currentVersion.versionString} = ${fetchedLatestVersion > currentVersion}"
+        )
+        return fetchedLatestVersion.release()
+    }
+
+    private suspend fun handleVersionCheckFailure(timestamp: Long, error: Throwable) {
+        error.throwIfCancellation()
+        when (error) {
+            is VersionCheckerException.RateLimit -> Log.d(logTag, "Version: rate limit")
+            is VersionCheckerException.UnexpectedResponse -> {
+                saveVersion(timestamp, null)
+                Log.e(logTag, "Unable to check version", error)
+            }
+            else -> Log.e(logTag, "Unable to check version", error)
+        }
+    }
+
     private suspend fun saveVersion(timestamp: Long, version: String?) {
         store.updateLastCheckedVersion(timestamp, version)
     }
@@ -132,7 +139,7 @@ class VersionChecker(
         }
     }
 
-    private suspend fun readySnapshot(): LastCheckedVersionSnapshot? {
+    private suspend fun waitForSnapshot(): LastCheckedVersionSnapshot? {
         return when (val state = snapshots.value) {
             is VersionSnapshotState.Ready -> state.snapshot
             VersionSnapshotState.Loading -> {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/strategy/GitHubConfigStrategy.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/strategy/GitHubConfigStrategy.kt
@@ -16,6 +16,7 @@ class GitHubConfigStrategy(
     private val ttl: Double,
     private val fetcher: suspend (String) -> ByteArray
 ) : ConfigManagerStrategy {
+    @Volatile
     private var lastUpdatedAtMillis: Long? = null
 
     override suspend fun bundle(): ConfigBundle {
@@ -33,5 +34,9 @@ class GitHubConfigStrategy(
         val bundle = ConfigBundle.Companion.decode(data)
         lastUpdatedAtMillis = SystemClock.elapsedRealtime()
         return bundle
+    }
+
+    override fun resetTTL() {
+        lastUpdatedAtMillis = null
     }
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/strategy/GitHubReleaseStrategy.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/strategy/GitHubReleaseStrategy.kt
@@ -6,9 +6,9 @@ package com.algoritmico.passepartout.business.strategy
 
 import android.util.Log
 import com.algoritmico.passepartout.business.extensions.JSON
+import com.algoritmico.passepartout.business.extensions.toSemanticVersionOrNull
 import com.algoritmico.passepartout.business.managers.VersionCheckerException
 import com.algoritmico.passepartout.business.managers.VersionCheckerStrategy
-import com.algoritmico.passepartout.business.managers.toSemanticVersionOrNull
 import com.algoritmico.passepartout.models.ChangelogEntry
 import com.algoritmico.passepartout.models.SemanticVersion
 import kotlinx.serialization.SerialName

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/strategy/GitHubReleaseStrategy.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/strategy/GitHubReleaseStrategy.kt
@@ -7,7 +7,6 @@ package com.algoritmico.passepartout.business.strategy
 import android.util.Log
 import com.algoritmico.passepartout.business.extensions.JSON
 import com.algoritmico.passepartout.business.managers.VersionCheckerException
-import com.algoritmico.passepartout.business.managers.VersionCheckerSnapshot
 import com.algoritmico.passepartout.business.managers.VersionCheckerStrategy
 import com.algoritmico.passepartout.business.managers.toSemanticVersionOrNull
 import com.algoritmico.passepartout.models.ChangelogEntry
@@ -20,9 +19,7 @@ class GitHubReleaseStrategy(
     private val releaseURL: String,
     private val changelogURL: (String) -> String,
     private val rateLimit: Double,
-    private val fetcher: suspend (String) -> ByteArray,
-    private val onSaveVersion: suspend (Long, String?) -> Unit,
-    private val onLastSnapshot: () -> VersionCheckerSnapshot?
+    private val fetcher: suspend (String) -> ByteArray
 ) : VersionCheckerStrategy {
     override suspend fun latestVersion(sinceTimestamp: Long?): SemanticVersion {
         if (sinceTimestamp != null) {
@@ -43,10 +40,6 @@ class GitHubReleaseStrategy(
         return semanticVersion
     }
 
-    override suspend fun saveVersion(timestamp: Long, version: String?) {
-        onSaveVersion(timestamp, version)
-    }
-
     override suspend fun fetchChangelog(version: String): List<ChangelogEntry> {
         val url = changelogURL(version)
         val text = fetcher(url).decodeToString()
@@ -57,8 +50,6 @@ class GitHubReleaseStrategy(
             }
     }
 
-    override val lastSnapshot: VersionCheckerSnapshot?
-        get() = onLastSnapshot()
 }
 
 private fun String.toChangelogEntry(id: Int): ChangelogEntry? {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/Dependencies.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/Dependencies.kt
@@ -24,6 +24,7 @@ import com.algoritmico.passepartout.models.AppConfiguration
 import com.algoritmico.passepartout.models.DistributionTarget
 import com.algoritmico.passepartout.models.Event
 import io.partout.PartoutTunnel
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 
 //region Constants
@@ -110,7 +111,8 @@ fun AppConfiguration.newTunnel(
 
 fun AppConfiguration.newVersionChecker(
     logTag: String,
-    preferences: DataStore<Preferences>
+    preferences: DataStore<Preferences>,
+    coroutineScope: CoroutineScope
 ): VersionChecker {
     val changelogURL = constants.github::urlForChangelog
     val isCached = false
@@ -118,6 +120,7 @@ fun AppConfiguration.newVersionChecker(
     return VersionChecker(
         logTag = logTag,
         store = preferences,
+        coroutineScope = coroutineScope,
         strategy = GitHubReleaseStrategy(
             logTag = logTag,
             releaseURL = constants.github.latestReleaseURL,

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/Dependencies.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/Dependencies.kt
@@ -6,6 +6,8 @@ package com.algoritmico.passepartout.context
 
 import android.content.Context
 import android.content.Intent
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
 import com.algoritmico.passepartout.PassepartoutVpnService
 import com.algoritmico.passepartout.PassepartoutWrapper
 import com.algoritmico.passepartout.business.extensions.betaConfigURL
@@ -14,16 +16,13 @@ import com.algoritmico.passepartout.business.extensions.urlForChangelog
 import com.algoritmico.passepartout.business.managers.ConfigManager
 import com.algoritmico.passepartout.business.managers.ProfileManager
 import com.algoritmico.passepartout.business.managers.VersionChecker
-import com.algoritmico.passepartout.business.managers.VersionCheckerSnapshot
 import com.algoritmico.passepartout.business.strategy.FileProfileRepository
 import com.algoritmico.passepartout.business.strategy.GitHubConfigStrategy
 import com.algoritmico.passepartout.business.strategy.GitHubReleaseStrategy
 import com.algoritmico.passepartout.business.strategy.URLFetcher
 import com.algoritmico.passepartout.models.AppConfiguration
-import com.algoritmico.passepartout.models.AppPreferenceKey
 import com.algoritmico.passepartout.models.DistributionTarget
 import com.algoritmico.passepartout.models.Event
-import com.algoritmico.passepartout.observables.UserPreferencesObservable
 import io.partout.PartoutTunnel
 import kotlinx.coroutines.flow.MutableSharedFlow
 
@@ -111,13 +110,14 @@ fun AppConfiguration.newTunnel(
 
 fun AppConfiguration.newVersionChecker(
     logTag: String,
-    userPreferencesObservable: UserPreferencesObservable
+    preferences: DataStore<Preferences>
 ): VersionChecker {
     val changelogURL = constants.github::urlForChangelog
     val isCached = false
     val timeout = constants.url.timeoutInterval
     return VersionChecker(
         logTag = logTag,
+        store = preferences,
         strategy = GitHubReleaseStrategy(
             logTag = logTag,
             releaseURL = constants.github.latestReleaseURL,
@@ -125,26 +125,6 @@ fun AppConfiguration.newVersionChecker(
             changelogURL = changelogURL,
             fetcher = { url ->
                 URLFetcher.fetch(url, isCached, timeout)
-            },
-            onSaveVersion = { timestamp, version ->
-                val fields = listOf(
-                    AppPreferenceKey.lastCheckedVersion,
-                    AppPreferenceKey.lastCheckedVersionDate
-                )
-                userPreferencesObservable.updatePreferences(fields) {
-                    it.copy(
-                        lastCheckedVersionTimestamp = timestamp,
-                        lastCheckedVersion = version ?: it.lastCheckedVersion
-                    )
-                }
-            },
-            onLastSnapshot = {
-                val timestamp = userPreferencesObservable.currentPreferences.lastCheckedVersionTimestamp
-                val version = userPreferencesObservable.currentPreferences.lastCheckedVersion
-                if (timestamp == null) {
-                    return@GitHubReleaseStrategy null
-                }
-                return@GitHubReleaseStrategy VersionCheckerSnapshot(timestamp, version)
             }
         ),
         currentVersion = bundle.versionNumber,

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
@@ -97,7 +97,7 @@ class AppContext(
         )
         versionChecker = appConfiguration.newVersionChecker(
             logTag,
-            userPreferencesObservable
+            context.userPreferencesStore
         )
 
         // Observables from managers
@@ -122,7 +122,7 @@ class AppContext(
             logTag,
             tunnel,
             profileManager,
-            userPreferencesObservable.preferences,
+            context.userPreferencesStore.data,
             coroutineScope
         )
         versionObservable = VersionObservable(

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import com.algoritmico.passepartout.PassepartoutWrapper
+import com.algoritmico.passepartout.business.extensions.throwIfCancellation
 import com.algoritmico.passepartout.business.managers.ConfigManager
 import com.algoritmico.passepartout.business.managers.ProfileManager
 import com.algoritmico.passepartout.business.managers.VersionChecker
@@ -139,11 +140,12 @@ class AppContext(
         applicationActiveJob = coroutineScope.launch {
             supervisorScope {
                 launch {
-                    configManager.refreshBundle()
-                    val flags = configManager.activeFlags
                     runCatching {
+                        configManager.refreshBundle()
+                        val flags = configManager.activeFlags
                         persistConfigFlags(flags)
                     }.onFailure {
+                        it.throwIfCancellation()
                         Log.e(logTag, "Unable to persist config flags", it)
                         configManager.resetTTL()
                     }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
@@ -97,7 +97,8 @@ class AppContext(
         )
         versionChecker = appConfiguration.newVersionChecker(
             logTag,
-            context.userPreferencesStore
+            context.userPreferencesStore,
+            coroutineScope
         )
 
         // Observables from managers
@@ -165,6 +166,7 @@ class AppContext(
         tunnelObservable.close()
         userPreferencesObservable.close()
         versionObservable.close()
+        versionChecker.close()
     }
 
     private suspend fun persistConfigFlags(flags: Set<ConfigFlag>) {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
@@ -141,7 +141,9 @@ class AppContext(
             supervisorScope {
                 launch {
                     runCatching {
-                        configManager.refreshBundle()
+                        if (!configManager.refreshBundle()) {
+                            return@runCatching
+                        }
                         val flags = configManager.activeFlags
                         persistConfigFlags(flags)
                     }.onFailure {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
@@ -18,6 +18,7 @@ import com.algoritmico.passepartout.context.newVersionChecker
 import com.algoritmico.passepartout.context.userPreferencesStore
 import com.algoritmico.passepartout.models.AppConfiguration
 import com.algoritmico.passepartout.models.AppPreferenceKey
+import com.algoritmico.passepartout.models.ConfigFlag
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -25,7 +26,7 @@ import kotlinx.coroutines.supervisorScope
 import java.io.Closeable
 
 class AppContext(
-    logTag: String,
+    private val logTag: String,
     context: Context,
     private val coroutineScope: CoroutineScope,
     requestVpnPermission: (Intent) -> Unit
@@ -139,12 +140,12 @@ class AppContext(
             supervisorScope {
                 launch {
                     configManager.refreshBundle()
-                    userPreferencesObservable.updatePreferences(
-                        fields = listOf(AppPreferenceKey.configFlags)
-                    ) {
-                        it.copy(
-                            configFlags = configManager.activeFlags.toList()
-                        )
+                    val flags = configManager.activeFlags
+                    runCatching {
+                        persistConfigFlags(flags)
+                    }.onFailure {
+                        Log.e(logTag, "Unable to persist config flags", it)
+                        configManager.resetTTL()
                     }
                 }
                 launch {
@@ -160,5 +161,13 @@ class AppContext(
         tunnelObservable.close()
         userPreferencesObservable.close()
         versionObservable.close()
+    }
+
+    private suspend fun persistConfigFlags(flags: Set<ConfigFlag>) {
+        userPreferencesObservable.updatePreferences(
+            fields = listOf(AppPreferenceKey.configFlags)
+        ) {
+            it.copy(configFlags = flags.toList())
+        }
     }
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
@@ -4,19 +4,20 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import com.algoritmico.passepartout.PassepartoutWrapper
-import com.algoritmico.passepartout.context.Tags
-import com.algoritmico.passepartout.context.appBundle
-import com.algoritmico.passepartout.context.appConstants
 import com.algoritmico.passepartout.business.managers.ConfigManager
 import com.algoritmico.passepartout.business.managers.ProfileManager
 import com.algoritmico.passepartout.business.managers.VersionChecker
+import com.algoritmico.passepartout.context.Tags
+import com.algoritmico.passepartout.context.appBundle
+import com.algoritmico.passepartout.context.appConstants
 import com.algoritmico.passepartout.context.isBetaSuggestedByAndroidAPI
-import com.algoritmico.passepartout.models.AppConfiguration
 import com.algoritmico.passepartout.context.newConfigManager
 import com.algoritmico.passepartout.context.newProfileManager
 import com.algoritmico.passepartout.context.newTunnel
 import com.algoritmico.passepartout.context.newVersionChecker
 import com.algoritmico.passepartout.context.userPreferencesStore
+import com.algoritmico.passepartout.models.AppConfiguration
+import com.algoritmico.passepartout.models.AppPreferenceKey
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -138,6 +139,13 @@ class AppContext(
             supervisorScope {
                 launch {
                     configManager.refreshBundle()
+                    userPreferencesObservable.updatePreferences(
+                        fields = listOf(AppPreferenceKey.configFlags)
+                    ) {
+                        it.copy(
+                            configFlags = configManager.activeFlags.toList()
+                        )
+                    }
                 }
                 launch {
                     versionChecker.checkLatestRelease()

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/TunnelObservable.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/TunnelObservable.kt
@@ -6,10 +6,11 @@ package com.algoritmico.passepartout.observables
 
 import android.content.Intent
 import android.util.Log
+import androidx.datastore.preferences.core.Preferences
 import com.algoritmico.passepartout.PassepartoutVpnService
 import com.algoritmico.passepartout.business.extensions.JSON
+import com.algoritmico.passepartout.business.extensions.toAppPreferences
 import com.algoritmico.passepartout.business.managers.ProfileManager
-import com.algoritmico.passepartout.models.AppPreferences
 import com.algoritmico.passepartout.models.AppProfileStatus
 import com.algoritmico.passepartout.models.AppTunnelInfo
 import com.algoritmico.passepartout.models.Event
@@ -49,7 +50,7 @@ class TunnelObservable(
     private val logTag: String,
     private val tunnel: PartoutTunnel,
     profileManager: ProfileManager,
-    preferences: Flow<AppPreferences>,
+    storeFlow: Flow<Preferences>,
     coroutineScope: CoroutineScope
 ) : Closeable {
     private val scope = CoroutineScope(
@@ -97,7 +98,7 @@ class TunnelObservable(
 
     private val onConnectIntent: (Intent) -> Unit = { intent ->
         val json = runBlocking {
-            val prefs = preferences.first()
+            val prefs = storeFlow.first().toAppPreferences()
             JSON.encode(prefs)
         }
         intent.putExtra(PassepartoutVpnService.EXTRA_TUNNEL_PREFERENCES, json)

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/TunnelObservable.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/TunnelObservable.kt
@@ -9,8 +9,9 @@ import android.util.Log
 import androidx.datastore.preferences.core.Preferences
 import com.algoritmico.passepartout.PassepartoutVpnService
 import com.algoritmico.passepartout.business.extensions.JSON
-import com.algoritmico.passepartout.business.extensions.toAppPreferences
+import com.algoritmico.passepartout.business.extensions.appPreferences
 import com.algoritmico.passepartout.business.managers.ProfileManager
+import com.algoritmico.passepartout.models.AppPreferences
 import com.algoritmico.passepartout.models.AppProfileStatus
 import com.algoritmico.passepartout.models.AppTunnelInfo
 import com.algoritmico.passepartout.models.Event
@@ -53,6 +54,8 @@ class TunnelObservable(
     storeFlow: Flow<Preferences>,
     coroutineScope: CoroutineScope
 ) : Closeable {
+    private val preferences: Flow<AppPreferences> = storeFlow.appPreferences(logTag)
+
     private val scope = CoroutineScope(
         coroutineScope.coroutineContext + SupervisorJob(coroutineScope.coroutineContext[Job])
     )
@@ -98,7 +101,7 @@ class TunnelObservable(
 
     private val onConnectIntent: (Intent) -> Unit = { intent ->
         val json = runBlocking {
-            val prefs = storeFlow.first().toAppPreferences()
+            val prefs = preferences.first()
             JSON.encode(prefs)
         }
         intent.putExtra(PassepartoutVpnService.EXTRA_TUNNEL_PREFERENCES, json)

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/UserPreferencesObservable.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/UserPreferencesObservable.kt
@@ -8,19 +8,16 @@ import android.util.Log
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
-import androidx.datastore.preferences.core.longPreferencesKey
-import androidx.datastore.preferences.core.stringPreferencesKey
-import androidx.datastore.preferences.core.stringSetPreferencesKey
-import com.algoritmico.passepartout.business.extensions.JSON
-import com.algoritmico.passepartout.business.extensions.throwIfCancellation
 import com.algoritmico.passepartout.business.extensions.default
+import com.algoritmico.passepartout.business.extensions.throwIfCancellation
+import com.algoritmico.passepartout.business.extensions.toAppPreferences
+import com.algoritmico.passepartout.business.extensions.toggleDnsFallback
 import com.algoritmico.passepartout.business.extensions.update
+import com.algoritmico.passepartout.business.extensions.updateExperimentalPreferences
 import com.algoritmico.passepartout.models.AppPreferenceKey
 import com.algoritmico.passepartout.models.AppPreferences
-import com.algoritmico.passepartout.models.ConfigFlag
 import com.algoritmico.passepartout.models.ExperimentalPreferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -83,8 +80,7 @@ class UserPreferencesObservable(
 
     suspend fun toggleDnsFallback() {
         editSafely {
-            val newValue = !(it[DNS_FALLS_BACK] ?: AppPreferences.default.dnsFallsBack)
-            it[DNS_FALLS_BACK] = newValue
+            val newValue = it.toggleDnsFallback()
             snapshot = snapshot.copy(dnsFallsBack = newValue)
         }
     }
@@ -93,10 +89,7 @@ class UserPreferencesObservable(
         transform: (ExperimentalPreferences) -> ExperimentalPreferences
     ) {
         editSafely {
-            val current = it[EXPERIMENTAL]?.decodePreference<ExperimentalPreferences>()
-                ?: snapshot.experimental
-            val newValue = transform(current)
-            it[EXPERIMENTAL] = JSON.encode(newValue)
+            val newValue = it.updateExperimentalPreferences(snapshot.experimental, transform)
             snapshot = snapshot.copy(experimental = newValue)
         }
     }
@@ -107,8 +100,8 @@ class UserPreferencesObservable(
     ) {
         editSafely {
             val newValue = transform(snapshot)
-            it.update(newValue, fields)
-            snapshot = snapshot.update(newValue, fields)
+            it.update(fields, newValue)
+            snapshot = snapshot.update(fields, newValue)
         }
     }
     //endregion
@@ -126,108 +119,6 @@ class UserPreferencesObservable(
 
     private fun savePreferences() {
         Log.d(logTag, "Preferences updated: $snapshot")
-    }
-
-    private fun Preferences.toAppPreferences(): AppPreferences {
-        val default = AppPreferences.default
-        return AppPreferences(
-            configFlags = this[CONFIG_FLAGS]
-                ?.mapNotNull { ConfigFlag.decode(it) }
-                ?.toMutableList()
-                ?: default.configFlags,
-            dnsFallsBack = this[DNS_FALLS_BACK]
-                ?: default.dnsFallsBack,
-            experimental = this[EXPERIMENTAL]
-                ?.decodePreference()
-                ?: default.experimental,
-            extensiveLogging = this[EXTENSIVE_LOGGING]
-                ?: default.extensiveLogging,
-            logsPrivateData = this[LOGS_PRIVATE_DATA]
-                ?: default.logsPrivateData,
-            newProfileEncoding = this[NEW_PROFILE_ENCODING]
-                ?: default.newProfileEncoding,
-            relaxedVerification = this[RELAXED_VERIFICATION]
-                ?: default.relaxedVerification,
-            skipsPurchases = this[SKIPS_PURCHASES]
-                ?: default.skipsPurchases,
-            deviceId = this[DEVICE_ID],
-            lastCheckedVersionTimestamp = this[LAST_CHECKED_VERSION_DATE],
-            lastCheckedVersion = this[LAST_CHECKED_VERSION],
-            lastUsedProfileUUID = this[LAST_USED_PROFILE_ID]
-        )
-    }
-
-    private fun MutablePreferences.update(new: AppPreferences, fields: List<AppPreferenceKey>) {
-        fields.forEach {
-            when (it) {
-                AppPreferenceKey.deviceId ->
-                    setOrRemove(
-                        DEVICE_ID,
-                        new.deviceId
-                    )
-                AppPreferenceKey.configFlags ->
-                    this[CONFIG_FLAGS] = new.configFlags.map { it.value }.toSet()
-                AppPreferenceKey.dnsFallsBack ->
-                    this[DNS_FALLS_BACK] = new.dnsFallsBack
-                AppPreferenceKey.experimental ->
-                    this[EXPERIMENTAL] = JSON.encode(new.experimental)
-                AppPreferenceKey.extensiveLogging ->
-                    this[EXTENSIVE_LOGGING] = new.extensiveLogging
-                AppPreferenceKey.lastCheckedVersion ->
-                    setOrRemove(
-                        LAST_CHECKED_VERSION,
-                        new.lastCheckedVersion
-                    )
-                AppPreferenceKey.lastCheckedVersionDate ->
-                    setOrRemove(
-                        LAST_CHECKED_VERSION_DATE,
-                        new.lastCheckedVersionTimestamp
-                    )
-                AppPreferenceKey.lastUsedProfileId ->
-                    setOrRemove(
-                        LAST_USED_PROFILE_ID,
-                        new.lastUsedProfileUUID
-                    )
-                AppPreferenceKey.logsPrivateData ->
-                    this[LOGS_PRIVATE_DATA] = new.logsPrivateData
-                AppPreferenceKey.newProfileEncoding ->
-                    this[NEW_PROFILE_ENCODING] = new.newProfileEncoding
-                AppPreferenceKey.relaxedVerification ->
-                    this[RELAXED_VERIFICATION] = new.relaxedVerification
-                AppPreferenceKey.skipsPurchases ->
-                    this[SKIPS_PURCHASES] = new.skipsPurchases
-            }
-        }
-    }
-
-    private fun <T> MutablePreferences.setOrRemove(key: Preferences.Key<T>, value: T?) {
-        if (value == null) {
-            remove(key)
-            return
-        }
-        this[key] = value
-    }
-
-    private inline fun <reified T> String.decodePreference(): T? {
-        return runCatching {
-            JSON.decode<T>(this)
-        }.getOrNull()
-    }
-
-    private companion object {
-        val CONFIG_FLAGS = stringSetPreferencesKey(AppPreferenceKey.configFlags.name)
-        val DEVICE_ID = stringPreferencesKey(AppPreferenceKey.deviceId.name)
-        val DNS_FALLS_BACK = booleanPreferencesKey(AppPreferenceKey.dnsFallsBack.name)
-        val EXPERIMENTAL = stringPreferencesKey(AppPreferenceKey.experimental.name)
-        val EXTENSIVE_LOGGING = booleanPreferencesKey(AppPreferenceKey.extensiveLogging.name)
-        val LAST_CHECKED_VERSION = stringPreferencesKey(AppPreferenceKey.lastCheckedVersion.name)
-        val LAST_CHECKED_VERSION_DATE =
-            longPreferencesKey(AppPreferenceKey.lastCheckedVersionDate.name)
-        val LAST_USED_PROFILE_ID = stringPreferencesKey(AppPreferenceKey.lastUsedProfileId.name)
-        val LOGS_PRIVATE_DATA = booleanPreferencesKey(AppPreferenceKey.logsPrivateData.name)
-        val NEW_PROFILE_ENCODING = booleanPreferencesKey(AppPreferenceKey.newProfileEncoding.name)
-        val RELAXED_VERIFICATION = booleanPreferencesKey(AppPreferenceKey.relaxedVerification.name)
-        val SKIPS_PURCHASES = booleanPreferencesKey(AppPreferenceKey.skipsPurchases.name)
     }
     //endregion
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/UserPreferencesObservable.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/UserPreferencesObservable.kt
@@ -9,10 +9,8 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.emptyPreferences
+import com.algoritmico.passepartout.business.extensions.appPreferences
 import com.algoritmico.passepartout.business.extensions.default
-import com.algoritmico.passepartout.business.extensions.throwIfCancellation
-import com.algoritmico.passepartout.business.extensions.toAppPreferences
 import com.algoritmico.passepartout.business.extensions.toggleDnsFallback
 import com.algoritmico.passepartout.business.extensions.update
 import com.algoritmico.passepartout.business.extensions.updateExperimentalPreferences
@@ -24,7 +22,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
@@ -40,16 +37,7 @@ class UserPreferencesObservable(
         coroutineScope.coroutineContext + SupervisorJob(coroutineScope.coroutineContext[Job])
     )
 
-    private val flow: Flow<Preferences>
-        get() {
-            return store.data.catch {
-                it.throwIfCancellation()
-                Log.e(logTag, "Unable to read preferences", it)
-                emit(emptyPreferences())
-            }
-        }
-
-    val preferences: Flow<AppPreferences> = flow.map { it.toAppPreferences() }
+    val preferences: Flow<AppPreferences> = store.appPreferences(logTag)
     val currentPreferences: AppPreferences
         get() = snapshot
     private var snapshot: AppPreferences


### PR DESCRIPTION
The config flags must be remembered as soon as they are fetched, so that they can be forwarded to the tunnel.

Take preferences store out of UserPreferencesObservable to make the store the single source of truth for all observables.