### PR TITLE
Android: Error handling (pt2)

### DIFF
--- a/app-android/app/proguard-rules.pro
+++ b/app-android/app/proguard-rules.pro
@@ -35,7 +35,7 @@
 # JNI entry points are exported with static Java_* symbols, and the native
 # tunnel backend also receives this controller object and calls into it by name
 # through GetMethodID. Keep the class and both sides of that method contract.
--keep class io.partout.vpn.JNITunnelController {
+-keep interface io.partout.NativeTunnelControllerJNI {
     native <methods>;
     public long setDelegate(long);
     public int setTunnel(java.lang.String);

--- a/app-android/app/src/main/cpp/src/wrapper.c
+++ b/app-android/app/src/main/cpp/src/wrapper.c
@@ -57,7 +57,8 @@ Java_com_algoritmico_passepartout_PassepartoutWrapper_partoutDaemonStart(
         jobject thiz,
         jstring profile,
         jstring cacheDir,
-        jobject controller
+        jobject controller,
+        jboolean logsSnapshots
 ) {
     (void)thiz;
     const char *cProfile = (*env)->GetStringUTFChars(env, profile, NULL);
@@ -71,6 +72,7 @@ Java_com_algoritmico_passepartout_PassepartoutWrapper_partoutDaemonStart(
     args.cache_dir = cCacheDir;
     args.profile = cProfile;
     args.is_daemon = false;
+    args.logs_snapshots = logsSnapshots;
     args.bindings = &bindings;
     const jint result = partout_daemon_start(&args);
 

--- a/app-android/app/src/main/cpp/src/wrapper.c
+++ b/app-android/app/src/main/cpp/src/wrapper.c
@@ -13,7 +13,7 @@
 static void daemon_bindings_free(partout_daemon_bindings *b);
 
 JNIEXPORT void JNICALL
-Java_com_algoritmico_passepartout_UnsafePassepartoutWrapper_partoutInit(
+Java_com_algoritmico_passepartout_PassepartoutWrapper_partoutInit(
         JNIEnv *env,
         jobject thiz,
         jstring tag,
@@ -29,14 +29,14 @@ Java_com_algoritmico_passepartout_UnsafePassepartoutWrapper_partoutInit(
 }
 
 JNIEXPORT jstring JNICALL
-Java_com_algoritmico_passepartout_UnsafePassepartoutWrapper_partoutVersion(JNIEnv *env, jobject thiz) {
+Java_com_algoritmico_passepartout_PassepartoutWrapper_partoutVersion(JNIEnv *env, jobject thiz) {
     (void)thiz;
     jstring jmsg = (*env)->NewStringUTF(env, partout_version());
     return jmsg;
 }
 
 JNIEXPORT void JNICALL
-Java_com_algoritmico_passepartout_UnsafePassepartoutWrapper_partoutImportProfile(
+Java_com_algoritmico_passepartout_PassepartoutWrapper_partoutImportProfile(
         JNIEnv *env,
         jobject thiz,
         jstring text,
@@ -52,7 +52,7 @@ Java_com_algoritmico_passepartout_UnsafePassepartoutWrapper_partoutImportProfile
 }
 
 JNIEXPORT jint JNICALL
-Java_com_algoritmico_passepartout_UnsafePassepartoutWrapper_partoutDaemonStart(
+Java_com_algoritmico_passepartout_PassepartoutWrapper_partoutDaemonStart(
         JNIEnv *env,
         jobject thiz,
         jstring profile,
@@ -80,7 +80,7 @@ Java_com_algoritmico_passepartout_UnsafePassepartoutWrapper_partoutDaemonStart(
 }
 
 JNIEXPORT void JNICALL
-Java_com_algoritmico_passepartout_UnsafePassepartoutWrapper_partoutDaemonStop(
+Java_com_algoritmico_passepartout_PassepartoutWrapper_partoutDaemonStop(
         JNIEnv *env,
         jobject thiz,
         jobject completion

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
@@ -5,7 +5,7 @@
 package com.algoritmico.passepartout
 
 import android.os.Bundle
-import android.util.Log
+import com.algoritmico.passepartout.context.AppLog
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
@@ -68,7 +68,7 @@ class MainActivity : ComponentActivity() {
         runCatchingNonFatal {
             profileImportLauncher.launch(Files.MIME_TYPES)
         }.onFailure {
-            Log.e(logTag, "Unable to open profile importer", it)
+            AppLog.e(logTag, "Unable to open profile importer", it)
             isProfileImporterOpen = false
             ErrorHandler.report(it)
         }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
@@ -10,7 +10,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.lifecycle.lifecycleScope
-import com.algoritmico.passepartout.business.extensions.throwIfFatal
+import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.context.Files
 import com.algoritmico.passepartout.context.Tags
 import com.algoritmico.passepartout.observables.AppContext
@@ -65,10 +65,9 @@ class MainActivity : ComponentActivity() {
     //region Import profile
     private fun openProfileImporter() {
         isProfileImporterOpen = true
-        runCatching {
+        runCatchingNonFatal {
             profileImportLauncher.launch(Files.MIME_TYPES)
         }.onFailure {
-            it.throwIfFatal()
             Log.e(logTag, "Unable to open profile importer", it)
             isProfileImporterOpen = false
             ErrorHandler.report(it)

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
@@ -10,10 +10,11 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.lifecycle.lifecycleScope
-import com.algoritmico.passepartout.observables.AppContext
-import com.algoritmico.passepartout.observables.ErrorHandler
+import com.algoritmico.passepartout.business.extensions.throwIfFatal
 import com.algoritmico.passepartout.context.Files
 import com.algoritmico.passepartout.context.Tags
+import com.algoritmico.passepartout.observables.AppContext
+import com.algoritmico.passepartout.observables.ErrorHandler
 import com.algoritmico.passepartout.ui.PassepartoutApp
 
 class MainActivity : ComponentActivity() {
@@ -67,9 +68,7 @@ class MainActivity : ComponentActivity() {
         runCatching {
             profileImportLauncher.launch(Files.MIME_TYPES)
         }.onFailure {
-            if (it !is Exception) {
-                throw it
-            }
+            it.throwIfFatal()
             Log.e(logTag, "Unable to open profile importer", it)
             isProfileImporterOpen = false
             ErrorHandler.report(it)

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
@@ -19,6 +19,7 @@ import com.algoritmico.passepartout.business.extensions.JSON
 import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.context.AppLog
 import com.algoritmico.passepartout.context.Tags
+import com.algoritmico.passepartout.context.TunnelConstants
 import com.algoritmico.passepartout.context.appBundle
 import com.algoritmico.passepartout.context.lastTunnelPreferences
 import com.algoritmico.passepartout.context.lastTunnelProfile
@@ -88,7 +89,8 @@ class PassepartoutVpnService: VpnService() {
             val code = library.partoutDaemonStart(
                 profileJSON,
                 cacheDir.absolutePath,
-                controller
+                controller,
+                logsSnapshots
             )
             if (code != 0) {
                 throw PartoutException(code, null)
@@ -140,6 +142,9 @@ class PassepartoutVpnService: VpnService() {
         override fun onServiceStopped() {
             postStoppedNotification()
         }
+
+        override val logsSnapshots: Boolean
+            get() = TunnelConstants.LOGS_SNAPSHOTS
 
         private fun readPreferences(intent: Intent?): AppPreferences? {
             val intentPreferencesJSON = intent?.getStringExtra(EXTRA_TUNNEL_PREFERENCES)
@@ -278,10 +283,14 @@ class PassepartoutVpnService: VpnService() {
     }
 
     private fun updateNotification(snapshot: TunnelSnapshot) {
-        AppLog.e(logTag, "updateNotification()")
+        if (engine.logsSnapshots) {
+            AppLog.e(logTag, "updateNotification()")
+        }
         val notificationManager = NotificationManagerCompat.from(this)
         if (!notificationManager.areNotificationsEnabled()) {
-            AppLog.w(logTag, "Skip VPN notification update, notifications are disabled")
+            if (engine.logsSnapshots) {
+                AppLog.w(logTag, "Skip VPN notification update, notifications are disabled")
+            }
             return
         }
         val notification = createNotification(snapshot)

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
@@ -146,10 +146,9 @@ class PassepartoutVpnService: VpnService() {
                 Log.i(logTag, "Load last preferences")
                 runCatchingNonFatal {
                     readLastFile(lastPreferencesFile)
-                }.getOrElse {
+                }.onFailure {
                     Log.w(logTag, "Unable to read last tunnel preferences", it)
-                    null
-                }
+                }.getOrNull()
             } else {
                 Log.i(logTag, "Load and persist start preferences")
                 runCatchingNonFatal {
@@ -162,10 +161,9 @@ class PassepartoutVpnService: VpnService() {
             return preferencesJSON?.let { json ->
                 runCatchingNonFatal {
                     JSON.decode<AppPreferences>(json)
-                }.getOrElse {
+                }.onFailure {
                     Log.w(logTag, "Unable to decode preferences JSON", it)
-                    null
-                }
+                }.getOrNull()
             }
         }
 

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
@@ -24,11 +24,11 @@ import com.algoritmico.passepartout.context.lastTunnelPreferences
 import com.algoritmico.passepartout.context.lastTunnelProfile
 import com.algoritmico.passepartout.models.AppPreferences
 import com.algoritmico.passepartout.ui.extensions.NotificationTransferFormatter
+import io.partout.NativeTunnelControllerJNI
 import io.partout.PartoutVpnServiceRuntime
 import io.partout.abi.PartoutException
 import io.partout.models.TaggedProfile
 import io.partout.models.TunnelSnapshot
-import io.partout.vpn.JNITunnelController
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -64,7 +64,7 @@ class PassepartoutVpnService: VpnService() {
 
         override suspend fun start(
             intent: Intent?,
-            controller: JNITunnelController,
+            controller: NativeTunnelControllerJNI,
             profileJSON: String
         ) = withContext(Dispatchers.IO) {
             Log.e(logTag, ">>> Started service")

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
@@ -17,6 +17,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.ServiceCompat
 import com.algoritmico.passepartout.business.extensions.JSON
+import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.context.Tags
 import com.algoritmico.passepartout.context.appBundle
 import com.algoritmico.passepartout.context.lastTunnelPreferences
@@ -119,10 +120,10 @@ class PassepartoutVpnService: VpnService() {
 
         override suspend fun deleteLastProfile(id: String) {
             withContext(Dispatchers.IO) {
-                runCatching {
+                runCatchingNonFatal {
                     val json = readLastFile(lastProfileFile)
                     val profile = JSON.decode<TaggedProfile>(json)
-                    if (profile.id != id) { return@runCatching }
+                    if (profile.id != id) { return@runCatchingNonFatal }
                     Log.i(logTag, "Forget last profile $id")
                     lastProfileFile.delete()
                 }.onFailure {
@@ -143,7 +144,7 @@ class PassepartoutVpnService: VpnService() {
             val intentPreferencesJSON = intent?.getStringExtra(EXTRA_TUNNEL_PREFERENCES)
             val preferencesJSON = if (intentPreferencesJSON.isNullOrBlank()) {
                 Log.i(logTag, "Load last preferences")
-                runCatching {
+                runCatchingNonFatal {
                     readLastFile(lastPreferencesFile)
                 }.getOrElse {
                     Log.w(logTag, "Unable to read last tunnel preferences", it)
@@ -151,7 +152,7 @@ class PassepartoutVpnService: VpnService() {
                 }
             } else {
                 Log.i(logTag, "Load and persist start preferences")
-                runCatching {
+                runCatchingNonFatal {
                     writeLastFile(lastPreferencesFile, intentPreferencesJSON)
                 }.onFailure {
                     Log.w(logTag, "Unable to write last tunnel preferences", it)
@@ -159,7 +160,7 @@ class PassepartoutVpnService: VpnService() {
                 intentPreferencesJSON
             }
             return preferencesJSON?.let { json ->
-                runCatching {
+                runCatchingNonFatal {
                     JSON.decode<AppPreferences>(json)
                 }.getOrElse {
                     Log.w(logTag, "Unable to decode preferences JSON", it)
@@ -177,7 +178,7 @@ class PassepartoutVpnService: VpnService() {
         private fun writeLastFile(file: File, json: String) {
             val atomicFile = AtomicFile(file)
             val stream = atomicFile.startWrite()
-            runCatching {
+            runCatchingNonFatal {
                 stream.write(json.toByteArray(Charsets.UTF_8))
                 atomicFile.finishWrite(stream)
             }.onFailure {
@@ -196,7 +197,7 @@ class PassepartoutVpnService: VpnService() {
             notificationTransfer.reset()
             updateCurrentProfileName(it)
         }
-        runCatching {
+        runCatchingNonFatal {
             ServiceCompat.startForeground(
                 this,
                 VPN_NOTIFICATION_ID,
@@ -285,7 +286,7 @@ class PassepartoutVpnService: VpnService() {
             return
         }
         val notification = createNotification(snapshot)
-        runCatching {
+        runCatchingNonFatal {
             notificationManager.notify(VPN_NOTIFICATION_ID, notification)
         }.onFailure {
             if (it is SecurityException) {
@@ -310,7 +311,7 @@ class PassepartoutVpnService: VpnService() {
             snapshot = null,
             isServiceStopped = true
         )
-        runCatching {
+        runCatchingNonFatal {
             notificationManager.notify(VPN_NOTIFICATION_ID, notification)
         }.onFailure {
             if (it is SecurityException) {
@@ -356,7 +357,7 @@ class PassepartoutVpnService: VpnService() {
     }
 
     private fun updateCurrentProfileName(profileJSON: String) {
-        runCatching {
+        runCatchingNonFatal {
             JSON.decode<TaggedProfile>(profileJSON).name
         }.onSuccess {
             currentProfileName = it

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
@@ -11,7 +11,7 @@ import android.content.pm.ServiceInfo
 import android.net.VpnService
 import android.os.IBinder
 import android.util.AtomicFile
-import android.util.Log
+import com.algoritmico.passepartout.context.AppLog
 import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -67,16 +67,16 @@ class PassepartoutVpnService: VpnService() {
             controller: NativeTunnelControllerJNI,
             profileJSON: String
         ) = withContext(Dispatchers.IO) {
-            Log.e(logTag, ">>> Started service")
+            AppLog.e(logTag, ">>> Started service")
 
             // FIXME: ###: Prepend bundle metadata
             val bundle = applicationContext.appBundle()
-            Log.e(logTag, ">>> Bundle: $bundle")
+            AppLog.e(logTag, ">>> Bundle: $bundle")
             updateCurrentProfileName(profileJSON)
 
             // Try preferences from intent, otherwise load last persisted
             val preferences = readPreferences(intent)
-            Log.e(logTag, ">>> Preferences: $preferences")
+            AppLog.e(logTag, ">>> Preferences: $preferences")
 
             // Initialize the library with the intent preferences
 //            val openvpn_version = preferences?.configFlags ? 3 : 2
@@ -124,10 +124,10 @@ class PassepartoutVpnService: VpnService() {
                     val json = readLastFile(lastProfileFile)
                     val profile = JSON.decode<TaggedProfile>(json)
                     if (profile.id != id) { return@runCatchingNonFatal }
-                    Log.i(logTag, "Forget last profile $id")
+                    AppLog.i(logTag, "Forget last profile $id")
                     lastProfileFile.delete()
                 }.onFailure {
-                    Log.e(logTag, "Unable to forget last profile", it)
+                    AppLog.e(logTag, "Unable to forget last profile", it)
                 }
             }
         }
@@ -143,18 +143,18 @@ class PassepartoutVpnService: VpnService() {
         private fun readPreferences(intent: Intent?): AppPreferences? {
             val intentPreferencesJSON = intent?.getStringExtra(EXTRA_TUNNEL_PREFERENCES)
             val preferencesJSON = if (intentPreferencesJSON.isNullOrBlank()) {
-                Log.i(logTag, "Load last preferences")
+                AppLog.i(logTag, "Load last preferences")
                 runCatchingNonFatal {
                     readLastFile(lastPreferencesFile)
                 }.onFailure {
-                    Log.w(logTag, "Unable to read last tunnel preferences", it)
+                    AppLog.w(logTag, "Unable to read last tunnel preferences", it)
                 }.getOrNull()
             } else {
-                Log.i(logTag, "Load and persist start preferences")
+                AppLog.i(logTag, "Load and persist start preferences")
                 runCatchingNonFatal {
                     writeLastFile(lastPreferencesFile, intentPreferencesJSON)
                 }.onFailure {
-                    Log.w(logTag, "Unable to write last tunnel preferences", it)
+                    AppLog.w(logTag, "Unable to write last tunnel preferences", it)
                 }
                 intentPreferencesJSON
             }
@@ -162,7 +162,7 @@ class PassepartoutVpnService: VpnService() {
                 runCatchingNonFatal {
                     JSON.decode<AppPreferences>(json)
                 }.onFailure {
-                    Log.w(logTag, "Unable to decode preferences JSON", it)
+                    AppLog.w(logTag, "Unable to decode preferences JSON", it)
                 }.getOrNull()
             }
         }
@@ -203,7 +203,7 @@ class PassepartoutVpnService: VpnService() {
                 ServiceInfo.FOREGROUND_SERVICE_TYPE_SYSTEM_EXEMPTED
             )
         }.onFailure {
-            Log.e(logTag, "Unable to start service in foreground", it)
+            AppLog.e(logTag, "Unable to start service in foreground", it)
             return START_NOT_STICKY
         }
         return runtime.onStartCommand(intent, flags, startId)
@@ -277,10 +277,10 @@ class PassepartoutVpnService: VpnService() {
     }
 
     private fun updateNotification(snapshot: TunnelSnapshot) {
-        Log.e(logTag, "updateNotification()")
+        AppLog.e(logTag, "updateNotification()")
         val notificationManager = NotificationManagerCompat.from(this)
         if (!notificationManager.areNotificationsEnabled()) {
-            Log.w(logTag, "Skip VPN notification update, notifications are disabled")
+            AppLog.w(logTag, "Skip VPN notification update, notifications are disabled")
             return
         }
         val notification = createNotification(snapshot)
@@ -288,7 +288,7 @@ class PassepartoutVpnService: VpnService() {
             notificationManager.notify(VPN_NOTIFICATION_ID, notification)
         }.onFailure {
             if (it is SecurityException) {
-                Log.w(logTag, "Unable to update VPN notification", it)
+                AppLog.w(logTag, "Unable to update VPN notification", it)
             } else {
                 throw it
             }
@@ -302,7 +302,7 @@ class PassepartoutVpnService: VpnService() {
 
         val notificationManager = NotificationManagerCompat.from(this)
         if (!notificationManager.areNotificationsEnabled()) {
-            Log.w(logTag, "Skip stopped VPN notification, notifications are disabled")
+            AppLog.w(logTag, "Skip stopped VPN notification, notifications are disabled")
             return
         }
         val notification = createNotification(
@@ -313,7 +313,7 @@ class PassepartoutVpnService: VpnService() {
             notificationManager.notify(VPN_NOTIFICATION_ID, notification)
         }.onFailure {
             if (it is SecurityException) {
-                Log.w(logTag, "Unable to show stopped VPN notification", it)
+                AppLog.w(logTag, "Unable to show stopped VPN notification", it)
             } else {
                 throw it
             }
@@ -360,7 +360,7 @@ class PassepartoutVpnService: VpnService() {
         }.onSuccess {
             currentProfileName = it
         }.onFailure {
-            Log.w(logTag, "Unable to decode VPN profile name", it)
+            AppLog.w(logTag, "Unable to decode VPN profile name", it)
         }
     }
 

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
@@ -11,17 +11,18 @@ import android.content.pm.ServiceInfo
 import android.net.VpnService
 import android.os.IBinder
 import android.util.AtomicFile
-import com.algoritmico.passepartout.context.AppLog
 import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.ServiceCompat
 import com.algoritmico.passepartout.business.extensions.JSON
 import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
+import com.algoritmico.passepartout.context.AppLog
 import com.algoritmico.passepartout.context.Tags
 import com.algoritmico.passepartout.context.appBundle
 import com.algoritmico.passepartout.context.lastTunnelPreferences
 import com.algoritmico.passepartout.context.lastTunnelProfile
+import com.algoritmico.passepartout.context.logPreamble
 import com.algoritmico.passepartout.models.AppPreferences
 import com.algoritmico.passepartout.ui.extensions.NotificationTransferFormatter
 import io.partout.NativeTunnelControllerJNI
@@ -67,9 +68,9 @@ class PassepartoutVpnService: VpnService() {
             controller: NativeTunnelControllerJNI,
             profileJSON: String
         ) = withContext(Dispatchers.IO) {
-            AppLog.e(logTag, ">>> Started service")
+            applicationContext.logPreamble(logTag)
 
-            // FIXME: ###: Prepend bundle metadata
+            AppLog.e(logTag, ">>> Started service")
             val bundle = applicationContext.appBundle()
             AppLog.e(logTag, ">>> Bundle: $bundle")
             updateCurrentProfileName(profileJSON)

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
@@ -4,17 +4,21 @@
 
 package com.algoritmico.passepartout
 
+import android.Manifest
 import android.app.Notification
 import android.app.PendingIntent
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
 import android.net.VpnService
+import android.os.Build
 import android.os.IBinder
 import android.util.AtomicFile
 import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.ServiceCompat
+import androidx.core.content.ContextCompat
 import com.algoritmico.passepartout.business.extensions.JSON
 import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.context.AppLog
@@ -201,14 +205,16 @@ class PassepartoutVpnService: VpnService() {
             notificationTransfer.reset()
             updateCurrentProfileName(it)
         }
-        runCatchingNonFatal {
-            ServiceCompat.startForeground(
-                this,
-                VPN_NOTIFICATION_ID,
-                createNotification(snapshot = null),
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_SYSTEM_EXEMPTED
-            )
-        }.onFailure {
+        try {
+            if (!canPostNotifications()) {
+                AppLog.w(logTag, "Unable to start service in foreground, notifications are disabled")
+                return START_NOT_STICKY
+            }
+            startForegroundGracefully(createNotification(snapshot = null))
+        } catch (it: SecurityException) {
+            AppLog.e(logTag, "Unable to start service in foreground", it)
+            return START_NOT_STICKY
+        } catch (it: RuntimeException) {
             AppLog.e(logTag, "Unable to start service in foreground", it)
             return START_NOT_STICKY
         }
@@ -287,21 +293,17 @@ class PassepartoutVpnService: VpnService() {
             AppLog.e(logTag, "updateNotification()")
         }
         val notificationManager = NotificationManagerCompat.from(this)
-        if (!notificationManager.areNotificationsEnabled()) {
+        if (!canPostNotifications(notificationManager)) {
             if (engine.logsSnapshots) {
                 AppLog.w(logTag, "Skip VPN notification update, notifications are disabled")
             }
             return
         }
         val notification = createNotification(snapshot)
-        runCatchingNonFatal {
+        try {
             notificationManager.notify(VPN_NOTIFICATION_ID, notification)
-        }.onFailure {
-            if (it is SecurityException) {
-                AppLog.w(logTag, "Unable to update VPN notification", it)
-            } else {
-                throw it
-            }
+        } catch (it: SecurityException) {
+            AppLog.w(logTag, "Unable to update VPN notification", it)
         }
     }
 
@@ -311,7 +313,7 @@ class PassepartoutVpnService: VpnService() {
         ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_DETACH)
 
         val notificationManager = NotificationManagerCompat.from(this)
-        if (!notificationManager.areNotificationsEnabled()) {
+        if (!canPostNotifications(notificationManager)) {
             AppLog.w(logTag, "Skip stopped VPN notification, notifications are disabled")
             return
         }
@@ -319,14 +321,10 @@ class PassepartoutVpnService: VpnService() {
             snapshot = null,
             isServiceStopped = true
         )
-        runCatchingNonFatal {
+        try {
             notificationManager.notify(VPN_NOTIFICATION_ID, notification)
-        }.onFailure {
-            if (it is SecurityException) {
-                AppLog.w(logTag, "Unable to show stopped VPN notification", it)
-            } else {
-                throw it
-            }
+        } catch (it: SecurityException) {
+            AppLog.w(logTag, "Unable to show stopped VPN notification", it)
         }
     }
 
@@ -357,6 +355,37 @@ class PassepartoutVpnService: VpnService() {
         NotificationManagerCompat
             .from(this)
             .cancel(VPN_NOTIFICATION_ID)
+    }
+
+    private fun startForegroundGracefully(notification: Notification) {
+        ServiceCompat.startForeground(
+            this,
+            VPN_NOTIFICATION_ID,
+            notification,
+            vpnForegroundServiceType
+        )
+    }
+
+    private val vpnForegroundServiceType: Int
+        get() {
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_SYSTEM_EXEMPTED
+            } else {
+                0
+            }
+        }
+
+    private fun canPostNotifications(
+        notificationManager: NotificationManagerCompat = NotificationManagerCompat.from(this)
+    ): Boolean {
+        if (!notificationManager.areNotificationsEnabled()) {
+            return false
+        }
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+                ContextCompat.checkSelfPermission(
+                    this,
+                    Manifest.permission.POST_NOTIFICATIONS
+                ) == PackageManager.PERMISSION_GRANTED
     }
 
     private fun resetNotificationState() {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
@@ -207,8 +207,7 @@ class PassepartoutVpnService: VpnService() {
         }
         try {
             if (!canPostNotifications()) {
-                AppLog.w(logTag, "Unable to start service in foreground, notifications are disabled")
-                return START_NOT_STICKY
+                AppLog.w(logTag, "Starting service in foreground with notifications disabled")
             }
             startForegroundGracefully(createNotification(snapshot = null))
         } catch (it: SecurityException) {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
@@ -181,9 +181,6 @@ class PassepartoutVpnService: VpnService() {
                 stream.write(json.toByteArray(Charsets.UTF_8))
                 atomicFile.finishWrite(stream)
             }.onFailure {
-                if (it !is Exception) {
-                    throw it
-                }
                 atomicFile.failWrite(stream)
                 throw it
             }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutWrapper.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutWrapper.kt
@@ -29,60 +29,6 @@ interface PassepartoutWrapperProtocol {
 }
 
 class PassepartoutWrapper: PassepartoutWrapperProtocol {
-    private val wrapper: PassepartoutWrapperProtocol?
-
-    init {
-        wrapper = runCatchingNonFatal {
-            UnsafePassepartoutWrapper()
-        }.onFailure {
-            Log.e(Tags.PARTOUT_JNI, "Unable to load JNI library", it)
-        }.getOrNull()
-    }
-
-    override fun partoutInit(tag: String, logsPrivateData: Boolean) {
-        wrapper?.partoutInit(tag, logsPrivateData)
-    }
-
-    override fun partoutVersion(): String {
-        if (wrapper == null) {
-            return "x.y.z"
-        }
-        return wrapper.partoutVersion()
-    }
-
-    override fun partoutDaemonStart(
-        profile: String,
-        cacheDir: String,
-        controller: NativeTunnelControllerJNI
-    ): Int {
-        if (wrapper == null) {
-            return -1
-        }
-        return wrapper.partoutDaemonStart(profile, cacheDir, controller)
-    }
-
-    override fun partoutDaemonStop(completion: PartoutCompletionCallback) {
-        if (wrapper == null) {
-            completion.onComplete(-1, null)
-            return
-        }
-        wrapper.partoutDaemonStop(completion)
-    }
-
-    override fun partoutImportProfile(
-        text: String,
-        name: String?,
-        completion: PartoutCompletionCallback
-    ) {
-        if (wrapper == null) {
-            completion.onComplete(-1, null)
-            return
-        }
-        wrapper.partoutImportProfile(text, name, completion)
-    }
-}
-
-private class UnsafePassepartoutWrapper: PassepartoutWrapperProtocol {
     override external fun partoutInit(tag: String, logsPrivateData: Boolean)
     override external fun partoutVersion(): String
     override external fun partoutImportProfile(
@@ -102,7 +48,11 @@ private class UnsafePassepartoutWrapper: PassepartoutWrapperProtocol {
     companion object {
         init {
             // Name of the NDK .so without "lib" prefix or ".so"
-            System.loadLibrary("passepartout_wrapper")
+            runCatchingNonFatal {
+                System.loadLibrary("passepartout_wrapper")
+            }.onFailure {
+                Log.e(Tags.PARTOUT_JNI, "Unable to load JNI library", it)
+            }.getOrNull()
         }
     }
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutWrapper.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutWrapper.kt
@@ -7,8 +7,8 @@ package com.algoritmico.passepartout
 import android.util.Log
 import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.context.Tags
+import io.partout.NativeTunnelControllerJNI
 import io.partout.abi.PartoutCompletionCallback
-import io.partout.vpn.JNITunnelController
 
 interface PassepartoutWrapperProtocol {
     fun partoutInit(tag: String, logsPrivateData: Boolean)
@@ -21,7 +21,7 @@ interface PassepartoutWrapperProtocol {
     fun partoutDaemonStart(
         profile: String,
         cacheDir: String,
-        controller: JNITunnelController
+        controller: NativeTunnelControllerJNI
     ): Int
     fun partoutDaemonStop(
         completion: PartoutCompletionCallback
@@ -53,7 +53,7 @@ class PassepartoutWrapper: PassepartoutWrapperProtocol {
     override fun partoutDaemonStart(
         profile: String,
         cacheDir: String,
-        controller: JNITunnelController
+        controller: NativeTunnelControllerJNI
     ): Int {
         if (wrapper == null) {
             return -1
@@ -93,7 +93,7 @@ private class UnsafePassepartoutWrapper: PassepartoutWrapperProtocol {
     override external fun partoutDaemonStart(
         profile: String,
         cacheDir: String,
-        controller: JNITunnelController
+        controller: NativeTunnelControllerJNI
     ): Int
     override external fun partoutDaemonStop(
         completion: PartoutCompletionCallback

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutWrapper.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutWrapper.kt
@@ -34,10 +34,9 @@ class PassepartoutWrapper: PassepartoutWrapperProtocol {
     init {
         wrapper = runCatchingNonFatal {
             UnsafePassepartoutWrapper()
-        }.getOrElse {
+        }.onFailure {
             Log.e(Tags.PARTOUT_JNI, "Unable to load JNI library", it)
-            null
-        }
+        }.getOrNull()
     }
 
     override fun partoutInit(tag: String, logsPrivateData: Boolean) {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutWrapper.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutWrapper.kt
@@ -4,7 +4,7 @@
 
 package com.algoritmico.passepartout
 
-import android.util.Log
+import com.algoritmico.passepartout.context.AppLog
 import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.context.Tags
 import io.partout.NativeTunnelControllerJNI
@@ -51,7 +51,7 @@ class PassepartoutWrapper: PassepartoutWrapperProtocol {
             runCatchingNonFatal {
                 System.loadLibrary("passepartout_wrapper")
             }.onFailure {
-                Log.e(Tags.PARTOUT_JNI, "Unable to load JNI library", it)
+                AppLog.e(Tags.PARTOUT_JNI, "Unable to load JNI library", it)
             }.getOrNull()
         }
     }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutWrapper.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutWrapper.kt
@@ -21,7 +21,8 @@ interface PassepartoutWrapperProtocol {
     fun partoutDaemonStart(
         profile: String,
         cacheDir: String,
-        controller: NativeTunnelControllerJNI
+        controller: NativeTunnelControllerJNI,
+        logsSnapshots: Boolean
     ): Int
     fun partoutDaemonStop(
         completion: PartoutCompletionCallback
@@ -39,7 +40,8 @@ class PassepartoutWrapper: PassepartoutWrapperProtocol {
     override external fun partoutDaemonStart(
         profile: String,
         cacheDir: String,
-        controller: NativeTunnelControllerJNI
+        controller: NativeTunnelControllerJNI,
+        logsSnapshots: Boolean
     ): Int
     override external fun partoutDaemonStop(
         completion: PartoutCompletionCallback

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutWrapper.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutWrapper.kt
@@ -5,6 +5,7 @@
 package com.algoritmico.passepartout
 
 import android.util.Log
+import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.context.Tags
 import io.partout.abi.PartoutCompletionCallback
 import io.partout.vpn.JNITunnelController
@@ -31,7 +32,7 @@ class PassepartoutWrapper: PassepartoutWrapperProtocol {
     private val wrapper: PassepartoutWrapperProtocol?
 
     init {
-        wrapper = runCatching {
+        wrapper = runCatchingNonFatal {
             UnsafePassepartoutWrapper()
         }.getOrElse {
             Log.e(Tags.PARTOUT_JNI, "Unable to load JNI library", it)

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/AppPreferencesExtensions.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/AppPreferencesExtensions.kt
@@ -9,8 +9,8 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
-import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
@@ -47,7 +47,7 @@ fun DataStore<Preferences>.lastCheckedVersionSnapshots(
 
 private fun Flow<Preferences>.safePreferences(logTag: String): Flow<Preferences> {
     return catch {
-        it.throwIfCancellation()
+        it.throwIfFatal()
         Log.e(logTag, "Unable to read preferences", it)
         emit(emptyPreferences())
     }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/AppPreferencesExtensions.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/AppPreferencesExtensions.kt
@@ -147,7 +147,7 @@ private fun AppPreferences.lastCheckedVersionSnapshot(): LastCheckedVersionSnaps
 }
 
 private inline fun <reified T> String.decodePreference(): T? {
-    return runCatching {
+    return runCatchingNonFatal {
         JSON.decode<T>(this)
     }.getOrNull()
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/AppPreferencesExtensions.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/AppPreferencesExtensions.kt
@@ -4,7 +4,7 @@
 
 package com.algoritmico.passepartout.business.extensions
 
-import android.util.Log
+import com.algoritmico.passepartout.context.AppLog
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
@@ -48,7 +48,7 @@ fun DataStore<Preferences>.lastCheckedVersionSnapshots(
 private fun Flow<Preferences>.safePreferences(logTag: String): Flow<Preferences> {
     return catch {
         it.throwIfFatal()
-        Log.e(logTag, "Unable to read preferences", it)
+        AppLog.e(logTag, "Unable to read preferences", it)
         emit(emptyPreferences())
     }
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/Helpers.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/Helpers.kt
@@ -22,6 +22,15 @@ data class GenericException(
     }
 }
 
+inline fun <T> runCatchingNonFatal(block: () -> T): Result<T> {
+    return try {
+        Result.success(block())
+    } catch (error: Throwable) {
+        error.throwIfFatal()
+        Result.failure(error)
+    }
+}
+
 fun Throwable.throwIfFatal() {
     if (this !is Exception || this is CancellationException) {
         throw this
@@ -58,10 +67,9 @@ fun ByteArray.decodeAsTextOrNull(): String? {
         .newDecoder()
         .onMalformedInput(CodingErrorAction.REPORT)
         .onUnmappableCharacter(CodingErrorAction.REPORT)
-    return runCatching {
+    return runCatchingNonFatal {
         decoder.decode(ByteBuffer.wrap(this)).toString()
     }.getOrElse {
-        it.throwIfFatal()
         when (it) {
             is CharacterCodingException -> null
             else -> throw it

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/Helpers.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/Helpers.kt
@@ -22,8 +22,8 @@ data class GenericException(
     }
 }
 
-fun Throwable.throwIfCancellation() {
-    if (this is CancellationException) {
+fun Throwable.throwIfFatal() {
+    if (this !is Exception || this is CancellationException) {
         throw this
     }
 }
@@ -61,7 +61,7 @@ fun ByteArray.decodeAsTextOrNull(): String? {
     return runCatching {
         decoder.decode(ByteBuffer.wrap(this)).toString()
     }.getOrElse {
-        it.throwIfCancellation()
+        it.throwIfFatal()
         when (it) {
             is CharacterCodingException -> null
             else -> throw it

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/Helpers.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/Helpers.kt
@@ -4,6 +4,8 @@
 
 package com.algoritmico.passepartout.business.extensions
 
+import android.util.Log
+import com.algoritmico.passepartout.context.Tags
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -64,6 +66,7 @@ inline fun <T> runCatchingNonFatal(block: () -> T): NonFatalResult<T> {
     return try {
         NonFatalResult(Result.success(block()))
     } catch (error: Throwable) {
+        Log.e(Tags.OOB, "runCatchingNonFatal(): $error")
         NonFatalResult(Result.failure(error))
     }
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/Helpers.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/Helpers.kt
@@ -66,7 +66,7 @@ inline fun <T> runCatchingNonFatal(block: () -> T): NonFatalResult<T> {
     return try {
         NonFatalResult(Result.success(block()))
     } catch (error: Throwable) {
-        Log.e(Tags.OOB, "runCatchingNonFatal(): $error")
+        Log.d(Tags.OOB, "runCatchingNonFatal(): $error")
         NonFatalResult(Result.failure(error))
     }
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/Helpers.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/Helpers.kt
@@ -22,12 +22,49 @@ data class GenericException(
     }
 }
 
-inline fun <T> runCatchingNonFatal(block: () -> T): Result<T> {
-    return try {
-        Result.success(block())
-    } catch (error: Throwable) {
+class NonFatalResult<T> @PublishedApi internal constructor(
+    @PublishedApi internal val result: Result<T>
+) {
+    inline fun onSuccess(action: (value: T) -> Unit): NonFatalResult<T> {
+        result.onSuccess(action)
+        return this
+    }
+
+    inline fun onFailure(action: (exception: Throwable) -> Unit): NonFatalResult<T> {
+        val error = result.exceptionOrNull() ?: return this
         error.throwIfFatal()
-        Result.failure(error)
+        action(error)
+        return this
+    }
+
+    inline fun getOrElse(onFailure: (exception: Throwable) -> T): T {
+        val error = result.exceptionOrNull()
+        if (error != null) {
+            error.throwIfFatal()
+            return onFailure(error)
+        }
+        return result.getOrThrow()
+    }
+
+    fun getOrNull(): T? {
+        val error = result.exceptionOrNull()
+        if (error != null) {
+            error.throwIfFatal()
+            return null
+        }
+        return result.getOrNull()
+    }
+
+    fun getOrThrow(): T {
+        return result.getOrThrow()
+    }
+}
+
+inline fun <T> runCatchingNonFatal(block: () -> T): NonFatalResult<T> {
+    return try {
+        NonFatalResult(Result.success(block()))
+    } catch (error: Throwable) {
+        NonFatalResult(Result.failure(error))
     }
 }
 
@@ -69,12 +106,11 @@ fun ByteArray.decodeAsTextOrNull(): String? {
         .onUnmappableCharacter(CodingErrorAction.REPORT)
     return runCatchingNonFatal {
         decoder.decode(ByteBuffer.wrap(this)).toString()
-    }.getOrElse {
-        when (it) {
-            is CharacterCodingException -> null
-            else -> throw it
+    }.onFailure {
+        if (it !is CharacterCodingException) {
+            throw it
         }
-    }
+    }.getOrNull()
 }
 
 private fun ByteArray.hasBinaryControlBytes(): Boolean {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/Helpers.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/Helpers.kt
@@ -4,7 +4,7 @@
 
 package com.algoritmico.passepartout.business.extensions
 
-import android.util.Log
+import com.algoritmico.passepartout.context.AppLog
 import com.algoritmico.passepartout.context.Tags
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.Json
@@ -66,7 +66,7 @@ inline fun <T> runCatchingNonFatal(block: () -> T): NonFatalResult<T> {
     return try {
         NonFatalResult(Result.success(block()))
     } catch (error: Throwable) {
-        Log.d(Tags.OOB, "runCatchingNonFatal(): $error")
+        AppLog.d(Tags.OOB, "runCatchingNonFatal(): $error")
         NonFatalResult(Result.failure(error))
     }
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/SemanticVersionExtensions.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/SemanticVersionExtensions.kt
@@ -13,7 +13,7 @@ val SemanticVersion.Companion.max: SemanticVersion
     get() = SemanticVersion(255, 255, 255)
 
 fun String.toSemanticVersionOrNull(): SemanticVersion? {
-    return runCatching {
+    return runCatchingNonFatal {
         val parts = split(".")
         require(parts.size == 3)
         val major = parts[0].toInt()

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ConfigManager.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ConfigManager.kt
@@ -6,7 +6,7 @@ package com.algoritmico.passepartout.business.managers
 
 import android.util.Log
 import com.algoritmico.passepartout.business.extensions.JSON
-import com.algoritmico.passepartout.business.extensions.throwIfFatal
+import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.context.newEventFlow
 import com.algoritmico.passepartout.models.ConfigBundleConfig
 import com.algoritmico.passepartout.models.ConfigEventRefresh
@@ -43,7 +43,7 @@ class ConfigManager(
         if (!refreshMutex.tryLock()) {
             return false
         }
-        return runCatching {
+        return runCatchingNonFatal {
             Log.d(logTag, "Config: refreshing bundle...")
             val newBundle = strategy.bundle()
             val event = synchronized(bundleLock) {
@@ -57,7 +57,6 @@ class ConfigManager(
         }.also {
             refreshMutex.unlock()
         }.getOrElse {
-            it.throwIfFatal()
             when (it) {
                 is ConfigManagerException.RateLimit -> {
                     Log.d(logTag, "Config: TTL")

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ConfigManager.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ConfigManager.kt
@@ -63,7 +63,7 @@ class ConfigManager(
                     false
                 }
                 else -> {
-                    Log.e(logTag, "Unable to refresh config flags", it)
+                    Log.e(logTag, "Config: Unable to refresh flags", it)
                     throw it
                 }
             }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ConfigManager.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ConfigManager.kt
@@ -6,7 +6,7 @@ package com.algoritmico.passepartout.business.managers
 
 import android.util.Log
 import com.algoritmico.passepartout.business.extensions.JSON
-import com.algoritmico.passepartout.business.extensions.throwIfCancellation
+import com.algoritmico.passepartout.business.extensions.throwIfFatal
 import com.algoritmico.passepartout.context.newEventFlow
 import com.algoritmico.passepartout.models.ConfigBundleConfig
 import com.algoritmico.passepartout.models.ConfigEventRefresh
@@ -57,7 +57,7 @@ class ConfigManager(
         }.also {
             refreshMutex.unlock()
         }.getOrElse {
-            it.throwIfCancellation()
+            it.throwIfFatal()
             when (it) {
                 is ConfigManagerException.RateLimit -> {
                     Log.d(logTag, "Config: TTL")

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ConfigManager.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ConfigManager.kt
@@ -128,7 +128,7 @@ class ConfigBundle(
             val map = JSON
                 .decode<Map<String, ConfigBundleConfig>>(data.decodeToString())
                 .mapNotNull { (key, value) ->
-                    ConfigFlag.Companion.decode(key)?.let { it to value }
+                    ConfigFlag.decode(key)?.let { it to value }
                 }
                 .toMap()
             return ConfigBundle(map)

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ConfigManager.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ConfigManager.kt
@@ -4,7 +4,7 @@
 
 package com.algoritmico.passepartout.business.managers
 
-import android.util.Log
+import com.algoritmico.passepartout.context.AppLog
 import com.algoritmico.passepartout.business.extensions.JSON
 import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.context.newEventFlow
@@ -44,26 +44,26 @@ class ConfigManager(
             return false
         }
         return runCatchingNonFatal {
-            Log.d(logTag, "Config: refreshing bundle...")
+            AppLog.d(logTag, "Config: refreshing bundle...")
             val newBundle = strategy.bundle()
             val event = synchronized(bundleLock) {
                 bundle = newBundle
                 refreshEvent(newBundle)
             }
             _events.emit(event)
-            Log.i(logTag, "Config: active flags = ${event.flags}")
-            Log.d(logTag, "Config: $newBundle")
+            AppLog.i(logTag, "Config: active flags = ${event.flags}")
+            AppLog.d(logTag, "Config: $newBundle")
             true
         }.also {
             refreshMutex.unlock()
         }.getOrElse {
             when (it) {
                 is ConfigManagerException.RateLimit -> {
-                    Log.d(logTag, "Config: TTL")
+                    AppLog.d(logTag, "Config: TTL")
                     false
                 }
                 else -> {
-                    Log.e(logTag, "Config: Unable to refresh flags", it)
+                    AppLog.e(logTag, "Config: Unable to refresh flags", it)
                     throw it
                 }
             }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ProfileManager.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ProfileManager.kt
@@ -8,7 +8,7 @@ import android.util.Log
 import com.algoritmico.passepartout.PassepartoutWrapper
 import com.algoritmico.passepartout.business.extensions.JSON
 import com.algoritmico.passepartout.business.extensions.fingerprint
-import com.algoritmico.passepartout.business.extensions.throwIfCancellation
+import com.algoritmico.passepartout.business.extensions.throwIfFatal
 import com.algoritmico.passepartout.context.newEventFlow
 import com.algoritmico.passepartout.models.AppProfileHeader
 import com.algoritmico.passepartout.models.Event
@@ -63,7 +63,7 @@ class ProfileManager(
                 library.partoutImportProfile(text, name, completion)
             }
         }.getOrElse {
-            it.throwIfCancellation()
+            it.throwIfFatal()
             when (it) {
                 is PartoutException -> throw ProfileManagerException.ABI(it.payload)
                 else -> throw it

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ProfileManager.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ProfileManager.kt
@@ -4,7 +4,7 @@
 
 package com.algoritmico.passepartout.business.managers
 
-import android.util.Log
+import com.algoritmico.passepartout.context.AppLog
 import com.algoritmico.passepartout.PassepartoutWrapper
 import com.algoritmico.passepartout.business.extensions.JSON
 import com.algoritmico.passepartout.business.extensions.fingerprint
@@ -51,7 +51,7 @@ class ProfileManager(
         runCatchingNonFatal {
             setProfiles(repository.fetchProfiles())
         }.onFailure {
-            Log.e(logTag, "Unable to load initial profiles", it)
+            AppLog.e(logTag, "Unable to load initial profiles", it)
             reportError(it)
         }
         _events.emit(ProfileEventReady())
@@ -110,7 +110,7 @@ class ProfileManager(
 
     private suspend fun publishProfiles() {
         val newHeaders = profiles.mapValues { it.value.appHeader() }
-        Log.d(logTag, "New headers: $newHeaders")
+        AppLog.d(logTag, "New headers: $newHeaders")
         _events.emit(ProfileEventLocalProfiles())
         _events.emit(
             ProfileEventRefresh(

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ProfileManager.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ProfileManager.kt
@@ -8,7 +8,7 @@ import android.util.Log
 import com.algoritmico.passepartout.PassepartoutWrapper
 import com.algoritmico.passepartout.business.extensions.JSON
 import com.algoritmico.passepartout.business.extensions.fingerprint
-import com.algoritmico.passepartout.business.extensions.throwIfFatal
+import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.context.newEventFlow
 import com.algoritmico.passepartout.models.AppProfileHeader
 import com.algoritmico.passepartout.models.Event
@@ -48,7 +48,7 @@ class ProfileManager(
     val events: SharedFlow<Event> = _events.asSharedFlow()
 
     suspend fun loadInitialProfiles(reportError: (Throwable) -> Unit) {
-        runCatching {
+        runCatchingNonFatal {
             setProfiles(repository.fetchProfiles())
         }.onFailure {
             Log.e(logTag, "Unable to load initial profiles", it)
@@ -58,12 +58,11 @@ class ProfileManager(
     }
 
     suspend fun importText(text: String, name: String?) {
-        val result = runCatching {
+        val result = runCatchingNonFatal {
             PartoutResult.await { completion ->
                 library.partoutImportProfile(text, name, completion)
             }
         }.getOrElse {
-            it.throwIfFatal()
             when (it) {
                 is PartoutException -> throw ProfileManagerException.ABI(it.payload)
                 else -> throw it

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/VersionChecker.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/VersionChecker.kt
@@ -4,7 +4,7 @@
 
 package com.algoritmico.passepartout.business.managers
 
-import android.util.Log
+import com.algoritmico.passepartout.context.AppLog
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import com.algoritmico.passepartout.business.extensions.LastCheckedVersionSnapshot
@@ -84,9 +84,9 @@ class VersionChecker(
                 latestRelease
             }
             if (release == null) {
-                Log.d(logTag, "Version: current is latest version")
+                AppLog.d(logTag, "Version: current is latest version")
             } else {
-                Log.i(logTag, "Version: new version available at ${release.url}")
+                AppLog.i(logTag, "Version: new version available at ${release.url}")
                 _events.emit(VersionEventNew(release = release))
             }
         }.also {
@@ -104,10 +104,10 @@ class VersionChecker(
 
     private suspend fun newReleaseOrNull(timestamp: Long): VersionRelease? {
         val lastCheckedTimestamp = waitForSnapshot()?.timestamp
-        Log.d(logTag, "Version: checking for updates...")
+        AppLog.d(logTag, "Version: checking for updates...")
         val fetchedLatestVersion = strategy.latestVersion(lastCheckedTimestamp)
         saveVersion(timestamp, fetchedLatestVersion.versionString)
-        Log.i(
+        AppLog.i(
             logTag,
             "Version: ${fetchedLatestVersion.versionString} > " +
                     "${currentVersion.versionString} = ${fetchedLatestVersion > currentVersion}"
@@ -117,12 +117,12 @@ class VersionChecker(
 
     private suspend fun handleVersionCheckFailure(timestamp: Long, error: Throwable) {
         when (error) {
-            is VersionCheckerException.RateLimit -> Log.d(logTag, "Version: rate limit")
+            is VersionCheckerException.RateLimit -> AppLog.d(logTag, "Version: rate limit")
             is VersionCheckerException.UnexpectedResponse -> {
                 saveVersion(timestamp, null)
-                Log.e(logTag, "Unable to check version", error)
+                AppLog.e(logTag, "Unable to check version", error)
             }
-            else -> Log.e(logTag, "Unable to check version", error)
+            else -> AppLog.e(logTag, "Unable to check version", error)
         }
     }
 

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/VersionChecker.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/VersionChecker.kt
@@ -11,7 +11,7 @@ import com.algoritmico.passepartout.business.extensions.LastCheckedVersionSnapsh
 import com.algoritmico.passepartout.business.extensions.compareTo
 import com.algoritmico.passepartout.business.extensions.lastCheckedVersionSnapshots
 import com.algoritmico.passepartout.business.extensions.max
-import com.algoritmico.passepartout.business.extensions.throwIfCancellation
+import com.algoritmico.passepartout.business.extensions.throwIfFatal
 import com.algoritmico.passepartout.business.extensions.toSemanticVersionOrNull
 import com.algoritmico.passepartout.business.extensions.updateLastCheckedVersion
 import com.algoritmico.passepartout.business.extensions.versionString
@@ -116,7 +116,7 @@ class VersionChecker(
     }
 
     private suspend fun handleVersionCheckFailure(timestamp: Long, error: Throwable) {
-        error.throwIfCancellation()
+        error.throwIfFatal()
         when (error) {
             is VersionCheckerException.RateLimit -> Log.d(logTag, "Version: rate limit")
             is VersionCheckerException.UnexpectedResponse -> {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/VersionChecker.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/VersionChecker.kt
@@ -11,7 +11,7 @@ import com.algoritmico.passepartout.business.extensions.LastCheckedVersionSnapsh
 import com.algoritmico.passepartout.business.extensions.compareTo
 import com.algoritmico.passepartout.business.extensions.lastCheckedVersionSnapshots
 import com.algoritmico.passepartout.business.extensions.max
-import com.algoritmico.passepartout.business.extensions.throwIfFatal
+import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.business.extensions.toSemanticVersionOrNull
 import com.algoritmico.passepartout.business.extensions.updateLastCheckedVersion
 import com.algoritmico.passepartout.business.extensions.versionString
@@ -74,9 +74,9 @@ class VersionChecker(
         if (!mutex.tryLock()) {
             return
         }
-        runCatching {
+        runCatchingNonFatal {
             val now = System.currentTimeMillis()
-            val release = runCatching {
+            val release = runCatchingNonFatal {
                 newReleaseOrNull(now)
             }.onFailure {
                 handleVersionCheckFailure(now, it)
@@ -116,7 +116,6 @@ class VersionChecker(
     }
 
     private suspend fun handleVersionCheckFailure(timestamp: Long, error: Throwable) {
-        error.throwIfFatal()
         when (error) {
             is VersionCheckerException.RateLimit -> Log.d(logTag, "Version: rate limit")
             is VersionCheckerException.UnexpectedResponse -> {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/strategy/FileProfileRepository.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/strategy/FileProfileRepository.kt
@@ -4,7 +4,7 @@
 
 package com.algoritmico.passepartout.business.strategy
 
-import android.util.Log
+import com.algoritmico.passepartout.context.AppLog
 import com.algoritmico.passepartout.business.extensions.GenericException
 import com.algoritmico.passepartout.business.extensions.JSON
 import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
@@ -65,7 +65,7 @@ class FileProfileRepository(
         runCatchingNonFatal {
             loadIndex()
         }.onFailure {
-            Log.e(logTag, "Rebuilding malformed profile index", it)
+            AppLog.e(logTag, "Rebuilding malformed profile index", it)
             persistIndex(loadProfilesByIdFromObjects())
         }
     }
@@ -82,7 +82,7 @@ class FileProfileRepository(
         val objects = loadProfilesByIdFromObjects()
         val unknownIds = objects.keys - knownIds
         if (unknownIds.isNotEmpty()) {
-            Log.e(logTag, "Profile index missing ${unknownIds.size} entries, rebuilding")
+            AppLog.e(logTag, "Profile index missing ${unknownIds.size} entries, rebuilding")
             persistIndex(objects)
         }
         return objects

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/strategy/FileProfileRepository.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/strategy/FileProfileRepository.kt
@@ -7,6 +7,7 @@ package com.algoritmico.passepartout.business.strategy
 import android.util.Log
 import com.algoritmico.passepartout.business.extensions.GenericException
 import com.algoritmico.passepartout.business.extensions.JSON
+import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.business.managers.ProfileManagerException
 import com.algoritmico.passepartout.business.managers.ProfileRepository
 import io.partout.models.TaggedProfile
@@ -61,7 +62,7 @@ class FileProfileRepository(
             persistIndex(loadProfilesByIdFromObjects())
             return
         }
-        runCatching {
+        runCatchingNonFatal {
             loadIndex()
         }.onFailure {
             Log.e(logTag, "Rebuilding malformed profile index", it)
@@ -92,7 +93,7 @@ class FileProfileRepository(
             .listFiles { file -> file.isFile && file.extension == "json" }
             .orEmpty()
             .associate { file ->
-                val profile = runCatching {
+                val profile = runCatchingNonFatal {
                     JSON.decode<TaggedProfile>(file.readText())
                 }.getOrElse {
                     throw GenericException(
@@ -109,7 +110,7 @@ class FileProfileRepository(
     }
 
     private fun loadIndex(): IndexFile {
-        return runCatching {
+        return runCatchingNonFatal {
             JSON.decode<IndexFile>(indexFile.readText())
         }.getOrElse {
             throw GenericException("Unable to decode profile index", it)

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/strategy/GitHubConfigStrategy.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/strategy/GitHubConfigStrategy.kt
@@ -31,7 +31,7 @@ class GitHubConfigStrategy(
 
         Log.i(logTag, "Config (GitHub): fetching bundle from $url")
         val data = fetcher(url)
-        val bundle = ConfigBundle.Companion.decode(data)
+        val bundle = ConfigBundle.decode(data)
         lastUpdatedAtMillis = SystemClock.elapsedRealtime()
         return bundle
     }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/strategy/GitHubConfigStrategy.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/strategy/GitHubConfigStrategy.kt
@@ -5,7 +5,7 @@
 package com.algoritmico.passepartout.business.strategy
 
 import android.os.SystemClock
-import android.util.Log
+import com.algoritmico.passepartout.context.AppLog
 import com.algoritmico.passepartout.business.managers.ConfigBundle
 import com.algoritmico.passepartout.business.managers.ConfigManagerException
 import com.algoritmico.passepartout.business.managers.ConfigManagerStrategy
@@ -24,12 +24,12 @@ class GitHubConfigStrategy(
         lastUpdatedAtMillis?.let { lastUpdatedAtMillis ->
             val elapsed = (now - lastUpdatedAtMillis) / 1000.0
             if (elapsed < ttl) {
-                Log.d(logTag, "Config (GitHub): elapsed $elapsed < $ttl")
+                AppLog.d(logTag, "Config (GitHub): elapsed $elapsed < $ttl")
                 throw ConfigManagerException.RateLimit
             }
         }
 
-        Log.i(logTag, "Config (GitHub): fetching bundle from $url")
+        AppLog.i(logTag, "Config (GitHub): fetching bundle from $url")
         val data = fetcher(url)
         val bundle = ConfigBundle.decode(data)
         lastUpdatedAtMillis = SystemClock.elapsedRealtime()

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/strategy/GitHubReleaseStrategy.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/strategy/GitHubReleaseStrategy.kt
@@ -4,7 +4,7 @@
 
 package com.algoritmico.passepartout.business.strategy
 
-import android.util.Log
+import com.algoritmico.passepartout.context.AppLog
 import com.algoritmico.passepartout.business.extensions.JSON
 import com.algoritmico.passepartout.business.extensions.toSemanticVersionOrNull
 import com.algoritmico.passepartout.business.managers.VersionCheckerException
@@ -25,7 +25,7 @@ class GitHubReleaseStrategy(
         if (sinceTimestamp != null) {
             val elapsed = (System.currentTimeMillis() - sinceTimestamp) / 1000.0
             if (elapsed < rateLimit) {
-                Log.d(logTag, "Version (GitHub): elapsed $elapsed < $rateLimit")
+                AppLog.d(logTag, "Version (GitHub): elapsed $elapsed < $rateLimit")
                 throw VersionCheckerException.RateLimit
             }
         }
@@ -34,7 +34,7 @@ class GitHubReleaseStrategy(
         val newVersion = json.name
         val semanticVersion = newVersion.toSemanticVersionOrNull()
         if (semanticVersion == null) {
-            Log.e(logTag, "Version (GitHub): unparsable release name '$newVersion'")
+            AppLog.e(logTag, "Version (GitHub): unparsable release name '$newVersion'")
             throw VersionCheckerException.UnexpectedResponse
         }
         return semanticVersion

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/strategy/URLFetcher.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/strategy/URLFetcher.kt
@@ -4,6 +4,7 @@
 
 package com.algoritmico.passepartout.business.strategy
 
+import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.IOException
@@ -19,7 +20,7 @@ object URLFetcher {
 
     private fun fetchBlocking(url: String, cached: Boolean, timeout: Double): ByteArray {
         val connection = URL(url).openConnection() as HttpURLConnection
-        return runCatching {
+        return runCatchingNonFatal {
             connection.requestMethod = "GET"
             connection.useCaches = cached
             connection.connectTimeout = timeout.toInt() * 1000

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/AppLog.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/AppLog.kt
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+package com.algoritmico.passepartout.context
+
+import android.util.Log
+
+enum class AppLogLevel {
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR
+}
+
+interface AppLogBackend {
+    fun log(
+        level: AppLogLevel,
+        tag: String,
+        message: String,
+        error: Throwable? = null
+    )
+}
+
+object AppLog {
+    @Volatile
+    private var backend: AppLogBackend = AndroidAppLogBackend
+
+    fun setBackend(backend: AppLogBackend): AppLogBackend {
+        val previous = this.backend
+        this.backend = backend
+        return previous
+    }
+
+    fun resetBackend() {
+        backend = AndroidAppLogBackend
+    }
+
+    fun d(tag: String, message: String, error: Throwable? = null) {
+        backend.log(AppLogLevel.DEBUG, tag, message, error)
+    }
+
+    fun i(tag: String, message: String, error: Throwable? = null) {
+        backend.log(AppLogLevel.INFO, tag, message, error)
+    }
+
+    fun w(tag: String, message: String, error: Throwable? = null) {
+        backend.log(AppLogLevel.WARN, tag, message, error)
+    }
+
+    fun e(tag: String, message: String, error: Throwable? = null) {
+        backend.log(AppLogLevel.ERROR, tag, message, error)
+    }
+}
+
+object NoOpAppLogBackend : AppLogBackend {
+    override fun log(
+        level: AppLogLevel,
+        tag: String,
+        message: String,
+        error: Throwable?
+    ) = Unit
+}
+
+private object AndroidAppLogBackend : AppLogBackend {
+    override fun log(
+        level: AppLogLevel,
+        tag: String,
+        message: String,
+        error: Throwable?
+    ) {
+        write {
+            when (level) {
+                AppLogLevel.DEBUG -> {
+                    if (error != null) Log.d(tag, message, error) else Log.d(tag, message)
+                }
+                AppLogLevel.INFO -> {
+                    if (error != null) Log.i(tag, message, error) else Log.i(tag, message)
+                }
+                AppLogLevel.WARN -> {
+                    if (error != null) Log.w(tag, message, error) else Log.w(tag, message)
+                }
+                AppLogLevel.ERROR -> {
+                    if (error != null) Log.e(tag, message, error) else Log.e(tag, message)
+                }
+            }
+        }
+    }
+
+    private inline fun write(block: () -> Int) {
+        try {
+            block()
+        } catch (error: RuntimeException) {
+            // Local JVM tests use mockable android.jar, where Log methods throw.
+            if (error.message?.contains("not mocked") != true) {
+                throw error
+            }
+        }
+    }
+}

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/ContextExtensions.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/ContextExtensions.kt
@@ -13,6 +13,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
 import com.algoritmico.passepartout.business.extensions.JSON
+import com.algoritmico.passepartout.business.extensions.versionString
 import com.algoritmico.passepartout.models.AppBundle
 import com.algoritmico.passepartout.models.AppConstants
 import com.algoritmico.passepartout.models.Credits
@@ -55,6 +56,40 @@ fun Context.appBundle(): AppBundle {
         bundleStrings = emptyMap()
     )
 }
+
+fun Context.logPreamble(logTag: String) {
+    val bundle = appBundle()
+    AppLog.e(logTag, "")
+    AppLog.e(logTag, "--- BEGIN ---")
+    AppLog.e(logTag, "")
+    AppLog.e(logTag, "App: ${bundle.versionString}")
+    AppLog.e(logTag, "OS: $androidOsString")
+    androidDeviceString?.let {
+        AppLog.e(logTag, "Device: $it")
+    }
+    AppLog.e(logTag, "")
+}
+
+private val Context.androidOsString: String
+    get() {
+        val version = Build.VERSION.RELEASE
+            .takeIf { it.isNotBlank() }
+            ?: "API ${Build.VERSION.SDK_INT}"
+        return "Android $version"
+    }
+
+private val Context.androidDeviceString: String?
+    get() {
+        val manufacturer = Build.MANUFACTURER.trim()
+        val model = Build.MODEL.trim()
+        return when {
+            manufacturer.isBlank() && model.isBlank() -> null
+            manufacturer.isBlank() -> model
+            model.isBlank() -> manufacturer
+            model.startsWith(manufacturer, ignoreCase = true) -> model
+            else -> "$manufacturer $model"
+        }
+    }
 
 private fun Context.packageInfo(): PackageInfo {
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/Dependencies.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/Dependencies.kt
@@ -33,6 +33,7 @@ object Tags {
     const val SERVICE = "PassepartoutVpnService"
     const val PARTOUT = "Partout"
     const val PARTOUT_JNI = "PartoutJNI"
+    const val OOB = "PassepartoutOOB"
 }
 
 object Files {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/Dependencies.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/Dependencies.kt
@@ -48,8 +48,12 @@ object Files {
     const val DEFAULT_PROFILE_NAME = "Imported profile"
 }
 
+object TunnelConstants {
+    const val LOGS_SNAPSHOTS = false
+    const val IS_FOREGROUND = true
+}
+
 private object Tuning {
-    const val TUNNEL_IS_FOREGROUND = true
     const val EVENT_BUFFER_CAPACITY = 64
     const val EVENT_REPLAY = 64
 }
@@ -105,7 +109,8 @@ fun AppConfiguration.newTunnel(
         logTag,
         applicationContext,
         PassepartoutVpnService::class.java,
-        Tuning.TUNNEL_IS_FOREGROUND,
+        TunnelConstants.IS_FOREGROUND,
+        TunnelConstants.LOGS_SNAPSHOTS,
         requestVpnPermission
     )
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import com.algoritmico.passepartout.PassepartoutWrapper
-import com.algoritmico.passepartout.business.extensions.throwIfCancellation
+import com.algoritmico.passepartout.business.extensions.throwIfFatal
 import com.algoritmico.passepartout.business.managers.ConfigManager
 import com.algoritmico.passepartout.business.managers.ProfileManager
 import com.algoritmico.passepartout.business.managers.VersionChecker
@@ -148,7 +148,7 @@ class AppContext(
                         val flags = configManager.activeFlags
                         persistConfigFlags(flags)
                     }.onFailure {
-                        it.throwIfCancellation()
+                        it.throwIfFatal()
                         Log.e(logTag, "Unable to persist config flags", it)
                         configManager.resetTTL()
                     }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
@@ -2,7 +2,7 @@ package com.algoritmico.passepartout.observables
 
 import android.content.Context
 import android.content.Intent
-import android.util.Log
+import com.algoritmico.passepartout.context.AppLog
 import com.algoritmico.passepartout.PassepartoutWrapper
 import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.business.managers.ConfigManager
@@ -52,7 +52,7 @@ class AppContext(
     val versionObservable: VersionObservable
 
     init {
-        Log.e(logTag, ">>> Started app")
+        AppLog.e(logTag, ">>> Started app")
 
         // User preferences
         userPreferencesObservable = UserPreferencesObservable(
@@ -61,17 +61,17 @@ class AppContext(
             applicationContext.userPreferencesStore
         )
         val preferences = userPreferencesObservable.currentPreferences
-        Log.i(logTag, ">>> Preferences: $preferences")
+        AppLog.i(logTag, ">>> Preferences: $preferences")
 
         library.partoutInit(Tags.PARTOUT, preferences.logsPrivateData)
         val partoutVersion = library.partoutVersion()
-        Log.i(logTag, ">>> Partout $partoutVersion")
+        AppLog.i(logTag, ">>> Partout $partoutVersion")
 
         // Static app configuration
         val bundle = applicationContext.appBundle()
-        Log.d(logTag, ">>> Bundle: $bundle")
+        AppLog.d(logTag, ">>> Bundle: $bundle")
         val constants = applicationContext.appConstants()
-        Log.d(logTag, ">>> Constants: $bundle")
+        AppLog.d(logTag, ">>> Constants: $bundle")
         appConfiguration = AppConfiguration(
             bundle = bundle,
             constants = constants
@@ -148,7 +148,7 @@ class AppContext(
                         val flags = configManager.activeFlags
                         persistConfigFlags(flags)
                     }.onFailure {
-                        Log.e(logTag, "Unable to persist config flags", it)
+                        AppLog.e(logTag, "Unable to persist config flags", it)
                         configManager.resetTTL()
                     }
                 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import com.algoritmico.passepartout.PassepartoutWrapper
-import com.algoritmico.passepartout.business.extensions.throwIfFatal
+import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.business.managers.ConfigManager
 import com.algoritmico.passepartout.business.managers.ProfileManager
 import com.algoritmico.passepartout.business.managers.VersionChecker
@@ -141,14 +141,13 @@ class AppContext(
         applicationActiveJob = coroutineScope.launch {
             supervisorScope {
                 launch {
-                    runCatching {
+                    runCatchingNonFatal {
                         if (!configManager.refreshBundle()) {
-                            return@runCatching
+                            return@runCatchingNonFatal
                         }
                         val flags = configManager.activeFlags
                         persistConfigFlags(flags)
                     }.onFailure {
-                        it.throwIfFatal()
                         Log.e(logTag, "Unable to persist config flags", it)
                         configManager.resetTTL()
                     }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/ErrorHandler.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/ErrorHandler.kt
@@ -4,7 +4,7 @@
 
 package com.algoritmico.passepartout.observables
 
-import android.util.Log
+import com.algoritmico.passepartout.context.AppLog
 import androidx.compose.ui.platform.UriHandler
 import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.business.extensions.throwIfFatal
@@ -25,7 +25,7 @@ object ErrorHandler {
     fun report(error: Throwable) {
         // This is a guard of last resort to rethrow CancellationException
         error.throwIfFatal()
-        Log.e(Tags.APP, "Invoke error handler", error)
+        AppLog.e(Tags.APP, "Invoke error handler", error)
         _errors.tryEmit(error.asAppError)
     }
 }
@@ -34,7 +34,7 @@ fun UriHandler.safeOpenUri(uri: String, handler: ErrorHandler) {
     runCatchingNonFatal {
         openUri(uri)
     }.onFailure {
-        Log.e(Tags.APP, "Unable to open URL ($uri)", it)
+        AppLog.e(Tags.APP, "Unable to open URL ($uri)", it)
         handler.report(it)
     }
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/ErrorHandler.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/ErrorHandler.kt
@@ -6,7 +6,7 @@ package com.algoritmico.passepartout.observables
 
 import android.util.Log
 import androidx.compose.ui.platform.UriHandler
-import com.algoritmico.passepartout.business.extensions.throwIfCancellation
+import com.algoritmico.passepartout.business.extensions.throwIfFatal
 import com.algoritmico.passepartout.context.Tags
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
@@ -23,7 +23,7 @@ object ErrorHandler {
 
     fun report(error: Throwable) {
         // This is a guard of last resort to rethrow CancellationException
-        error.throwIfCancellation()
+        error.throwIfFatal()
         Log.e(Tags.APP, "Invoke error handler", error)
         _errors.tryEmit(error.asAppError)
     }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/ErrorHandler.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/ErrorHandler.kt
@@ -6,6 +6,7 @@ package com.algoritmico.passepartout.observables
 
 import android.util.Log
 import androidx.compose.ui.platform.UriHandler
+import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.business.extensions.throwIfFatal
 import com.algoritmico.passepartout.context.Tags
 import kotlinx.coroutines.channels.BufferOverflow
@@ -30,7 +31,7 @@ object ErrorHandler {
 }
 
 fun UriHandler.safeOpenUri(uri: String, handler: ErrorHandler) {
-    runCatching {
+    runCatchingNonFatal {
         openUri(uri)
     }.onFailure {
         Log.e(Tags.APP, "Unable to open URL ($uri)", it)

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/ProfileImporter.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/ProfileImporter.kt
@@ -9,7 +9,7 @@ import android.net.Uri
 import android.provider.OpenableColumns
 import android.util.Log
 import com.algoritmico.passepartout.business.extensions.decodeAsTextOrNull
-import com.algoritmico.passepartout.business.extensions.throwIfFatal
+import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.business.managers.ProfileManager
 import com.algoritmico.passepartout.context.Files
 import kotlinx.coroutines.CoroutineScope
@@ -36,13 +36,12 @@ class ProfileImporter(
     fun importProfile(uri: Uri) {
         coroutineScope.launch {
             val profileName = displayName(uri) ?: Files.DEFAULT_PROFILE_NAME
-            runCatching {
+            runCatchingNonFatal {
                 val profileText = readProfileText(uri)
                 profileManager.importText(profileText, profileName)
             }.onSuccess {
                 onImportSuccess()
             }.onFailure {
-                it.throwIfFatal()
                 Log.e(logTag, "Import failure: $profileName", it)
                 errorHandler.report(ProfileImporterException.Failure(it))
             }
@@ -50,10 +49,9 @@ class ProfileImporter(
     }
 
     private suspend fun readProfileText(uri: Uri): String = withContext(Dispatchers.IO) {
-        val bytes = runCatching {
+        val bytes = runCatchingNonFatal {
             contentResolver.openInputStream(uri)?.use { it.readBytes() }
         }.getOrElse {
-            it.throwIfFatal()
             throw ProfileImporterException.Failure(it)
         }
         if (bytes == null) {
@@ -67,7 +65,7 @@ class ProfileImporter(
     }
 
     private suspend fun displayName(uri: Uri): String? = withContext(Dispatchers.IO) {
-        runCatching {
+        runCatchingNonFatal {
             contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
                 ?.use { cursor ->
                     if (!cursor.moveToFirst()) {
@@ -80,7 +78,6 @@ class ProfileImporter(
                     cursor.getString(displayNameIndex)
                 }
         }.getOrElse {
-            it.throwIfFatal()
             Log.e(logTag, "Unable to resolve profile file name: $uri", it)
             null
         }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/ProfileImporter.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/ProfileImporter.kt
@@ -9,7 +9,7 @@ import android.net.Uri
 import android.provider.OpenableColumns
 import android.util.Log
 import com.algoritmico.passepartout.business.extensions.decodeAsTextOrNull
-import com.algoritmico.passepartout.business.extensions.throwIfCancellation
+import com.algoritmico.passepartout.business.extensions.throwIfFatal
 import com.algoritmico.passepartout.business.managers.ProfileManager
 import com.algoritmico.passepartout.context.Files
 import kotlinx.coroutines.CoroutineScope
@@ -42,7 +42,7 @@ class ProfileImporter(
             }.onSuccess {
                 onImportSuccess()
             }.onFailure {
-                it.throwIfCancellation()
+                it.throwIfFatal()
                 Log.e(logTag, "Import failure: $profileName", it)
                 errorHandler.report(ProfileImporterException.Failure(it))
             }
@@ -53,7 +53,7 @@ class ProfileImporter(
         val bytes = runCatching {
             contentResolver.openInputStream(uri)?.use { it.readBytes() }
         }.getOrElse {
-            it.throwIfCancellation()
+            it.throwIfFatal()
             throw ProfileImporterException.Failure(it)
         }
         if (bytes == null) {
@@ -80,7 +80,7 @@ class ProfileImporter(
                     cursor.getString(displayNameIndex)
                 }
         }.getOrElse {
-            it.throwIfCancellation()
+            it.throwIfFatal()
             Log.e(logTag, "Unable to resolve profile file name: $uri", it)
             null
         }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/ProfileImporter.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/ProfileImporter.kt
@@ -7,7 +7,7 @@ package com.algoritmico.passepartout.observables
 import android.content.Context
 import android.net.Uri
 import android.provider.OpenableColumns
-import android.util.Log
+import com.algoritmico.passepartout.context.AppLog
 import com.algoritmico.passepartout.business.extensions.decodeAsTextOrNull
 import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.business.managers.ProfileManager
@@ -42,7 +42,7 @@ class ProfileImporter(
             }.onSuccess {
                 onImportSuccess()
             }.onFailure {
-                Log.e(logTag, "Import failure: $profileName", it)
+                AppLog.e(logTag, "Import failure: $profileName", it)
                 errorHandler.report(ProfileImporterException.Failure(it))
             }
         }
@@ -78,7 +78,7 @@ class ProfileImporter(
                     cursor.getString(displayNameIndex)
                 }
         }.getOrElse {
-            Log.e(logTag, "Unable to resolve profile file name: $uri", it)
+            AppLog.e(logTag, "Unable to resolve profile file name: $uri", it)
             null
         }
     }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/TunnelObservable.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/TunnelObservable.kt
@@ -5,7 +5,7 @@
 package com.algoritmico.passepartout.observables
 
 import android.content.Intent
-import android.util.Log
+import com.algoritmico.passepartout.context.AppLog
 import androidx.datastore.preferences.core.Preferences
 import com.algoritmico.passepartout.PassepartoutVpnService
 import com.algoritmico.passepartout.business.extensions.JSON
@@ -123,7 +123,7 @@ class TunnelObservable(
 
     suspend fun getEnvironmentValue(name: String): String? {
         val json = tunnel.requestEnvironmentValue(name)
-        Log.i(logTag, "TunnelObservable.getEnvironmentValue($name) = $json")
+        AppLog.i(logTag, "TunnelObservable.getEnvironmentValue($name) = $json")
         return json
     }
 
@@ -160,7 +160,7 @@ class TunnelObservable(
     private fun onUpdate(event: Event) {
         if (event !is ProfileEventDelete) { return }
         event.ids.forEach {
-            Log.i(logTag, "Disconnect from removed profile $it")
+            AppLog.i(logTag, "Disconnect from removed profile $it")
             tunnel.disconnect(it, forget = true) { _ -> }
         }
     }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/UserPreferencesObservable.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/UserPreferencesObservable.kt
@@ -11,6 +11,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import com.algoritmico.passepartout.business.extensions.appPreferences
 import com.algoritmico.passepartout.business.extensions.default
+import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.business.extensions.toggleDnsFallback
 import com.algoritmico.passepartout.business.extensions.update
 import com.algoritmico.passepartout.business.extensions.updateExperimentalPreferences
@@ -45,7 +46,7 @@ class UserPreferencesObservable(
 
     //region Lifecycle
     init {
-        snapshot = runCatching {
+        snapshot = runCatchingNonFatal {
             runBlocking {
                 preferences.first()
             }
@@ -93,7 +94,7 @@ class UserPreferencesObservable(
 
     //region Private
     private suspend fun editSafely(transform: suspend (MutablePreferences) -> Unit) {
-        runCatching {
+        runCatchingNonFatal {
             store.edit(transform)
             savePreferences()
         }.onFailure {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/UserPreferencesObservable.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/UserPreferencesObservable.kt
@@ -4,7 +4,7 @@
 
 package com.algoritmico.passepartout.observables
 
-import android.util.Log
+import com.algoritmico.passepartout.context.AppLog
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
@@ -51,7 +51,7 @@ class UserPreferencesObservable(
                 preferences.first()
             }
         }.getOrElse {
-            Log.e(logTag, "Unable to load preferences", it)
+            AppLog.e(logTag, "Unable to load preferences", it)
             AppPreferences.default
         }
     }
@@ -98,13 +98,13 @@ class UserPreferencesObservable(
             store.edit(transform)
             savePreferences()
         }.onFailure {
-            Log.e(logTag, "Unable to save preferences", it)
+            AppLog.e(logTag, "Unable to save preferences", it)
             throw it
         }
     }
 
     private fun savePreferences() {
-        Log.d(logTag, "Preferences updated: $snapshot")
+        AppLog.d(logTag, "Preferences updated: $snapshot")
     }
     //endregion
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/UserPreferencesObservable.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/UserPreferencesObservable.kt
@@ -50,9 +50,6 @@ class UserPreferencesObservable(
                 preferences.first()
             }
         }.getOrElse {
-            if (it !is Exception) {
-                throw it
-            }
             Log.e(logTag, "Unable to load preferences", it)
             AppPreferences.default
         }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/app/AppCoordinator.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/app/AppCoordinator.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.observables.LocalErrorHandler
 import com.algoritmico.passepartout.observables.ProfileObservable
 import com.algoritmico.passepartout.observables.TunnelObservable
@@ -89,7 +90,7 @@ fun AppCoordinator(
             val profileIds = contextualProfileIds
             clearContextualMode()
             coroutineScope.launch {
-                runCatching {
+                runCatchingNonFatal {
                     profileObservable.remove(profileIds)
                 }.onFailure {
                     Log.e(logTag, "Unable to delete profiles", it)

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/app/AppCoordinator.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/app/AppCoordinator.kt
@@ -4,7 +4,7 @@
 
 package com.algoritmico.passepartout.ui.app
 
-import android.util.Log
+import com.algoritmico.passepartout.context.AppLog
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -93,7 +93,7 @@ fun AppCoordinator(
                 runCatchingNonFatal {
                     profileObservable.remove(profileIds)
                 }.onFailure {
-                    Log.e(logTag, "Unable to delete profiles", it)
+                    AppLog.e(logTag, "Unable to delete profiles", it)
                     errorHandler.report(it)
                 }
             }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/app/ProfileContainerView.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/app/ProfileContainerView.kt
@@ -47,7 +47,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.algoritmico.passepartout.business.extensions.throwIfCancellation
+import com.algoritmico.passepartout.business.extensions.throwIfFatal
 import com.algoritmico.passepartout.models.AppProfileHeader
 import com.algoritmico.passepartout.models.AppProfileStatus
 import com.algoritmico.passepartout.models.AppTunnelInfo
@@ -143,7 +143,7 @@ fun ProfileContainerView(
                     true
                 }
             }.getOrElse {
-                it.throwIfCancellation()
+                it.throwIfFatal()
                 when (it) {
                     is TunnelObservableException.Interactive -> {
                         interactiveProfile = it.profile

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/app/ProfileContainerView.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/app/ProfileContainerView.kt
@@ -47,7 +47,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.algoritmico.passepartout.business.extensions.throwIfFatal
+import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.models.AppProfileHeader
 import com.algoritmico.passepartout.models.AppProfileStatus
 import com.algoritmico.passepartout.models.AppTunnelInfo
@@ -129,7 +129,7 @@ fun ProfileContainerView(
         requestedConnection = request
         selectProfile(profileId)
         coroutineScope.launch {
-            val didStart = runCatching {
+            val didStart = runCatchingNonFatal {
                 if (enabled) {
                     val connectionProfile = profile ?: profileObservable.profile(profileId)
                     if (connectionProfile == null) {
@@ -143,7 +143,6 @@ fun ProfileContainerView(
                     true
                 }
             }.getOrElse {
-                it.throwIfFatal()
                 when (it) {
                     is TunnelObservableException.Interactive -> {
                         interactiveProfile = it.profile
@@ -457,10 +456,10 @@ private fun openVpnSettings(context: Context, errorHandler: ErrorHandler) {
         Uri.fromParts("package", context.packageName, null)
     ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
 
-    runCatching {
+    runCatchingNonFatal {
         context.startActivity(vpnSettingsIntent)
     }.onFailure {
-        runCatching {
+        runCatchingNonFatal {
             context.startActivity(appSettingsIntent)
         }.onFailure {
             errorHandler.report(it)

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/ChangelogView.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/ChangelogView.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.algoritmico.passepartout.business.extensions.throwIfFatal
+import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.business.extensions.urlForIssue
 import com.algoritmico.passepartout.business.extensions.versionString
 import com.algoritmico.passepartout.models.ChangelogEntry
@@ -57,10 +57,9 @@ fun ChangelogView(
 
     LaunchedEffect(versionNumber, versionObservable) {
         isLoading = true
-        entries = runCatching {
+        entries = runCatchingNonFatal {
             versionObservable.fetchChangelog(versionNumber)
         }.getOrElse {
-            it.throwIfFatal()
             Log.w(TAG, "Unable to load changelog", it)
             emptyList()
         }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/ChangelogView.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/ChangelogView.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.algoritmico.passepartout.business.extensions.throwIfFatal
 import com.algoritmico.passepartout.business.extensions.urlForIssue
 import com.algoritmico.passepartout.business.extensions.versionString
 import com.algoritmico.passepartout.models.ChangelogEntry
@@ -59,6 +60,7 @@ fun ChangelogView(
         entries = runCatching {
             versionObservable.fetchChangelog(versionNumber)
         }.getOrElse {
+            it.throwIfFatal()
             Log.w(TAG, "Unable to load changelog", it)
             emptyList()
         }
@@ -74,7 +76,6 @@ fun ChangelogView(
                 CircularProgressIndicator()
             }
         }
-
         entries.isEmpty() -> {
             Box(
                 modifier = modifier
@@ -89,7 +90,6 @@ fun ChangelogView(
                 )
             }
         }
-
         else -> {
             ChangelogListView(
                 modifier = modifier,

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/ChangelogView.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/ChangelogView.kt
@@ -4,7 +4,7 @@
 
 package com.algoritmico.passepartout.ui.settings
 
-import android.util.Log
+import com.algoritmico.passepartout.context.AppLog
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -60,7 +60,7 @@ fun ChangelogView(
         entries = runCatchingNonFatal {
             versionObservable.fetchChangelog(versionNumber)
         }.getOrElse {
-            Log.w(TAG, "Unable to load changelog", it)
+            AppLog.w(TAG, "Unable to load changelog", it)
             emptyList()
         }
         isLoading = false

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/CreditsView.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/CreditsView.kt
@@ -4,7 +4,7 @@
 
 package com.algoritmico.passepartout.ui.settings
 
-import android.util.Log
+import com.algoritmico.passepartout.context.AppLog
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -56,7 +56,7 @@ fun CreditsView(
         runCatchingNonFatal {
             context.credits()
         }.getOrElse {
-            Log.w(TAG, "Unable to load credits", it)
+            AppLog.w(TAG, "Unable to load credits", it)
             Credits(emptyList(), emptyList(), emptyMap())
         }
     }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/CreditsView.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/CreditsView.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.algoritmico.passepartout.business.extensions.throwIfFatal
 import com.algoritmico.passepartout.context.credits
 import com.algoritmico.passepartout.models.Credits
 import com.algoritmico.passepartout.models.CreditsLicensesInner
@@ -55,6 +56,7 @@ fun CreditsView(
         runCatching {
             context.credits()
         }.getOrElse {
+            it.throwIfFatal()
             Log.w(TAG, "Unable to load credits", it)
             Credits(emptyList(), emptyList(), emptyMap())
         }
@@ -149,7 +151,6 @@ private fun CreditsListView(
                 HorizontalDivider(modifier = Modifier.padding(start = 16.dp))
             }
         }
-
         if (notices.isNotEmpty()) {
             item {
                 CreditsSectionHeader("Notices")
@@ -173,7 +174,6 @@ private fun CreditsListView(
                 HorizontalDivider(modifier = Modifier.padding(start = 16.dp))
             }
         }
-
         if (languages.isNotEmpty()) {
             item {
                 CreditsSectionHeader("Translations")
@@ -243,9 +243,7 @@ private fun LicenseView(
                 runCatching {
                     URL(license.licenseURL).readText()
                 }.getOrElse {
-                    if (it !is Exception) {
-                        throw it
-                    }
+                    it.throwIfFatal()
                     "Unable to load license: ${it.localizedMessage ?: it::class.java.simpleName}"
                 }
             }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/CreditsView.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/CreditsView.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.algoritmico.passepartout.business.extensions.throwIfFatal
+import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.context.credits
 import com.algoritmico.passepartout.models.Credits
 import com.algoritmico.passepartout.models.CreditsLicensesInner
@@ -53,10 +53,9 @@ fun CreditsView(
 ) {
     val context = LocalContext.current
     val credits = remember(context) {
-        runCatching {
+        runCatchingNonFatal {
             context.credits()
         }.getOrElse {
-            it.throwIfFatal()
             Log.w(TAG, "Unable to load credits", it)
             Credits(emptyList(), emptyList(), emptyMap())
         }
@@ -240,10 +239,9 @@ private fun LicenseView(
     LaunchedEffect(license.licenseURL, content) {
         if (content == null) {
             val loadedContent = withContext(Dispatchers.IO) {
-                runCatching {
+                runCatchingNonFatal {
                     URL(license.licenseURL).readText()
                 }.getOrElse {
-                    it.throwIfFatal()
                     "Unable to load license: ${it.localizedMessage ?: it::class.java.simpleName}"
                 }
             }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/PreferencesAdvancedView.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/PreferencesAdvancedView.kt
@@ -31,13 +31,14 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.algoritmico.passepartout.business.extensions.default
 import com.algoritmico.passepartout.business.extensions.disable
 import com.algoritmico.passepartout.business.extensions.enable
 import com.algoritmico.passepartout.business.extensions.isAllowed
+import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.business.extensions.setAllowed
 import com.algoritmico.passepartout.business.extensions.unignore
 import com.algoritmico.passepartout.context.isBetaSuggestedByAndroidAPI
-import com.algoritmico.passepartout.business.extensions.default
 import com.algoritmico.passepartout.models.AppPreferences
 import com.algoritmico.passepartout.models.ConfigFlag
 import com.algoritmico.passepartout.models.DistributionTarget
@@ -79,7 +80,7 @@ fun PreferencesAdvancedView(
                             preference = preferences.experimental.preference(forFlag = flag),
                             onPreferenceChange = { preference ->
                                 coroutineScope.launch {
-                                    runCatching {
+                                    runCatchingNonFatal {
                                         userPreferencesObservable.updateExperimentalPreferences {
                                             it.setPreference(preference, forFlag = flag)
                                         }
@@ -105,7 +106,7 @@ fun PreferencesAdvancedView(
                             isAllowed = preferences.experimental.isAllowed(flag),
                             onAllowedChange = { isAllowed ->
                                 coroutineScope.launch {
-                                    runCatching {
+                                    runCatchingNonFatal {
                                         userPreferencesObservable.updateExperimentalPreferences {
                                             it.setAllowed(flag, isAllowed)
                                         }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/PreferencesView.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/PreferencesView.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.observables.LocalErrorHandler
 import com.algoritmico.passepartout.observables.UserPreferencesObservable
 import kotlinx.coroutines.flow.Flow
@@ -36,7 +37,7 @@ fun PreferencesView(
     ) {
         PreferenceSwitchRow("DNS fallback", userPreferencesObservable.dnsFallback) {
             coroutineScope.launch {
-                runCatching {
+                runCatchingNonFatal {
                     userPreferencesObservable.toggleDnsFallback()
                 }.onFailure {
                     errorHandler.report(it)

--- a/app-android/app/src/test/kotlin/com/algoritmico/passepartout/HelpersUnitTest.kt
+++ b/app-android/app/src/test/kotlin/com/algoritmico/passepartout/HelpersUnitTest.kt
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+package com.algoritmico.passepartout
+
+import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
+import kotlinx.coroutines.CancellationException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class HelpersUnitTest {
+    @Test
+    fun runCatchingNonFatal_runsChainedCleanupBeforeRethrowingFatalError() {
+        val error = LinkageError("fatal")
+        var didCleanUp = false
+
+        val thrown = assertThrows(LinkageError::class.java) {
+            runCatchingNonFatal<Unit> {
+                throw error
+            }.also {
+                didCleanUp = true
+            }.getOrElse {
+                fail("fatal errors must not be recoverable")
+            }
+        }
+
+        assertSame(error, thrown)
+        assertTrue(didCleanUp)
+    }
+
+    @Test
+    fun runCatchingNonFatal_runsChainedCleanupBeforeRethrowingCancellation() {
+        val error = CancellationException("cancelled")
+        var didCleanUp = false
+
+        val thrown = assertThrows(CancellationException::class.java) {
+            runCatchingNonFatal<Unit> {
+                throw error
+            }.also {
+                didCleanUp = true
+            }.onFailure {
+                fail("cancellation must not be recoverable")
+            }
+        }
+
+        assertSame(error, thrown)
+        assertTrue(didCleanUp)
+    }
+
+    @Test
+    fun runCatchingNonFatal_doesNotRethrowFromOnSuccessBeforeChainedCleanup() {
+        val error = LinkageError("fatal")
+        var didCleanUp = false
+
+        val thrown = assertThrows(LinkageError::class.java) {
+            runCatchingNonFatal<Unit> {
+                throw error
+            }.onSuccess {
+                fail("fatal errors must not be successful")
+            }.also {
+                didCleanUp = true
+            }.getOrThrow()
+        }
+
+        assertSame(error, thrown)
+        assertTrue(didCleanUp)
+    }
+
+    @Test
+    fun runCatchingNonFatal_recoversFromNonFatalExceptions() {
+        var didCleanUp = false
+        var didRecover = false
+
+        val value = runCatchingNonFatal<Int> {
+            throw IllegalStateException("non-fatal")
+        }.also {
+            didCleanUp = true
+        }.getOrElse {
+            didRecover = true
+            42
+        }
+
+        assertEquals(42, value)
+        assertTrue(didCleanUp)
+        assertTrue(didRecover)
+    }
+}

--- a/app-shared/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
+++ b/app-shared/Sources/CommonLibrary/ABI/TunnelABI+Cross.swift
@@ -61,7 +61,8 @@ extension TunnelABI {
             ctx,
             ref: bindings.controller,
             environment: environment,
-            betterPathFactory: betterPathFactory
+            betterPathFactory: betterPathFactory,
+            logsSnapshots: false
         )
         let factory = controller.newSocketFactory()
 


### PR DESCRIPTION
- Rethrow fatal errors and cancellations with runCatchingNonFatal
- Force unwrap JNI wrapper because nothing would work without it, better crash hard
- Review log messages and log levels
- Wrap logcat `Log` in `AppLog` for testing
- Suppress verbose snapshots
- Catch SecurityException in VPN service
- Fix fg type requiring API level 34