### PR TITLE
Android: Centralize scattered constants

### DIFF
--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
@@ -11,14 +11,13 @@ import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.lifecycle.lifecycleScope
 import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
-import com.algoritmico.passepartout.context.Files
-import com.algoritmico.passepartout.context.Tags
+import com.algoritmico.passepartout.context.defaultAndroidConstants
 import com.algoritmico.passepartout.observables.AppContext
-import com.algoritmico.passepartout.observables.ErrorHandler
 import com.algoritmico.passepartout.ui.PassepartoutApp
 
 class MainActivity : ComponentActivity() {
-    private val logTag = Tags.APP
+    private val androidConstants = defaultAndroidConstants
+    private val logTag = androidConstants.logTags.app
     private lateinit var appContext: AppContext
     private var isProfileImporterOpen = false
 
@@ -29,6 +28,7 @@ class MainActivity : ComponentActivity() {
             logTag,
             this,
             lifecycleScope,
+            androidConstants = androidConstants,
             requestVpnPermission = { permissionIntent ->
                 vpnPermissionLauncher.launch(permissionIntent)
             }
@@ -43,6 +43,7 @@ class MainActivity : ComponentActivity() {
                 appContext.diagnosticsObservable,
                 appContext.versionObservable,
                 appContext.appConfiguration,
+                appContext.androidConstants,
                 appContext.errorHandler,
                 onImportProfile = ::openProfileImporter
             )
@@ -67,11 +68,11 @@ class MainActivity : ComponentActivity() {
     private fun openProfileImporter() {
         isProfileImporterOpen = true
         runCatchingNonFatal {
-            profileImportLauncher.launch(Files.MIME_TYPES)
+            profileImportLauncher.launch(androidConstants.profileImport.mimeTypes.toTypedArray())
         }.onFailure {
             AppLog.e(logTag, "Unable to open profile importer", it)
             isProfileImporterOpen = false
-            ErrorHandler.report(it)
+            appContext.errorHandler.report(it)
         }
     }
 

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/MainActivity.kt
@@ -17,7 +17,7 @@ import com.algoritmico.passepartout.ui.PassepartoutApp
 
 class MainActivity : ComponentActivity() {
     private val androidConstants = defaultAndroidConstants
-    private val logTag = androidConstants.logTags.app
+    private val logTag = androidConstants.tags.app
     private lateinit var appContext: AppContext
     private var isProfileImporterOpen = false
 

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
@@ -22,8 +22,7 @@ import androidx.core.content.ContextCompat
 import com.algoritmico.passepartout.business.extensions.JSON
 import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.context.AppLog
-import com.algoritmico.passepartout.context.LocalConstants
-import com.algoritmico.passepartout.context.Tags
+import com.algoritmico.passepartout.context.defaultAndroidConstants
 import com.algoritmico.passepartout.context.appBundle
 import com.algoritmico.passepartout.context.lastTunnelPreferences
 import com.algoritmico.passepartout.context.lastTunnelProfile
@@ -41,9 +40,10 @@ import kotlinx.coroutines.withContext
 import java.io.File
 
 class PassepartoutVpnService: VpnService() {
-    private val logTag = Tags.SERVICE
-    private val jniLogTag = Tags.PARTOUT_JNI
-    private val logsSnapshots = LocalConstants.TUNNEL_LOGS_SNAPSHOTS
+    private val androidConstants = defaultAndroidConstants
+    private val logTag = androidConstants.logTags.service
+    private val jniLogTag = androidConstants.logTags.partoutJni
+    private val logsSnapshots = androidConstants.tunnel.logsSnapshots
 
     @Volatile
     private var currentProfileName: String? = null
@@ -66,9 +66,9 @@ class PassepartoutVpnService: VpnService() {
     private val engine = object : PartoutVpnServiceRuntime.Engine {
         private val library = PassepartoutWrapper()
         private val lastProfileFile: File
-            get() = applicationContext.lastTunnelProfile
+            get() = applicationContext.lastTunnelProfile(androidConstants.storage)
         private val lastPreferencesFile: File
-            get() = applicationContext.lastTunnelPreferences
+            get() = applicationContext.lastTunnelPreferences(androidConstants.storage)
 
         override suspend fun start(
             intent: Intent?,
@@ -92,7 +92,7 @@ class PassepartoutVpnService: VpnService() {
             // Initialize the library with the intent preferences
 //            val openvpn_version = preferences?.configFlags ? 3 : 2
             val logsPrivateData = preferences?.logsPrivateData ?: false
-            library.partoutInit(Tags.SERVICE_PARTOUT, logsPrivateData)
+            library.partoutInit(androidConstants.logTags.servicePartout, logsPrivateData)
 
             // This call retains the controller strongly
             val dnsFallsBack = preferences?.dnsFallsBack ?: true

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutVpnService.kt
@@ -41,8 +41,8 @@ import java.io.File
 
 class PassepartoutVpnService: VpnService() {
     private val androidConstants = defaultAndroidConstants
-    private val logTag = androidConstants.logTags.service
-    private val jniLogTag = androidConstants.logTags.partoutJni
+    private val logTag = androidConstants.tags.service
+    private val jniLogTag = androidConstants.tags.partoutJni
     private val logsSnapshots = androidConstants.tunnel.logsSnapshots
 
     @Volatile
@@ -92,7 +92,7 @@ class PassepartoutVpnService: VpnService() {
             // Initialize the library with the intent preferences
 //            val openvpn_version = preferences?.configFlags ? 3 : 2
             val logsPrivateData = preferences?.logsPrivateData ?: false
-            library.partoutInit(androidConstants.logTags.servicePartout, logsPrivateData)
+            library.partoutInit(androidConstants.tags.servicePartout, logsPrivateData)
 
             // This call retains the controller strongly
             val dnsFallsBack = preferences?.dnsFallsBack ?: true

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutWrapper.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutWrapper.kt
@@ -6,7 +6,7 @@ package com.algoritmico.passepartout
 
 import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.context.AppLog
-import com.algoritmico.passepartout.context.Tags
+import com.algoritmico.passepartout.context.defaultAndroidConstants
 import io.partout.NativeTunnelControllerJNI
 import io.partout.abi.PartoutCompletionCallback
 
@@ -57,7 +57,7 @@ class PassepartoutWrapper: PassepartoutWrapperProtocol {
             runCatchingNonFatal {
                 System.loadLibrary("passepartout_wrapper")
             }.onFailure {
-                AppLog.e(Tags.PARTOUT_JNI, "Unable to load JNI library", it)
+                AppLog.e(defaultAndroidConstants.logTags.partoutJni, "Unable to load JNI library", it)
             }.getOrNull()
         }
     }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutWrapper.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/PassepartoutWrapper.kt
@@ -57,7 +57,7 @@ class PassepartoutWrapper: PassepartoutWrapperProtocol {
             runCatchingNonFatal {
                 System.loadLibrary("passepartout_wrapper")
             }.onFailure {
-                AppLog.e(defaultAndroidConstants.logTags.partoutJni, "Unable to load JNI library", it)
+                AppLog.e(defaultAndroidConstants.tags.partoutJni, "Unable to load JNI library", it)
             }.getOrNull()
         }
     }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/Helpers.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/Helpers.kt
@@ -66,7 +66,7 @@ inline fun <T> runCatchingNonFatal(block: () -> T): NonFatalResult<T> {
     return try {
         NonFatalResult(Result.success(block()))
     } catch (error: Throwable) {
-        AppLog.d(defaultAndroidConstants.logTags.outOfBand, "runCatchingNonFatal(): $error")
+        AppLog.d(defaultAndroidConstants.tags.outOfBand, "runCatchingNonFatal(): $error")
         NonFatalResult(Result.failure(error))
     }
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/Helpers.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/Helpers.kt
@@ -5,7 +5,7 @@
 package com.algoritmico.passepartout.business.extensions
 
 import com.algoritmico.passepartout.context.AppLog
-import com.algoritmico.passepartout.context.Tags
+import com.algoritmico.passepartout.context.defaultAndroidConstants
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -66,7 +66,7 @@ inline fun <T> runCatchingNonFatal(block: () -> T): NonFatalResult<T> {
     return try {
         NonFatalResult(Result.success(block()))
     } catch (error: Throwable) {
-        AppLog.d(Tags.OOB, "runCatchingNonFatal(): $error")
+        AppLog.d(defaultAndroidConstants.logTags.outOfBand, "runCatchingNonFatal(): $error")
         NonFatalResult(Result.failure(error))
     }
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/IssueExtensions.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/extensions/IssueExtensions.kt
@@ -5,6 +5,7 @@
 package com.algoritmico.passepartout.business.extensions
 
 import com.algoritmico.passepartout.models.Issue
+import com.algoritmico.passepartout.ui.Strings
 import java.text.DateFormat
 import java.util.Date
 import java.util.Locale
@@ -35,7 +36,7 @@ val Issue.body: String
     }
 
 val Issue.subject: String
-    get() = "Passepartout/Android - Report issue"
+    get() = Strings.Unlocalized.Issues.subject
 
 private val timestampFormatter: DateFormat
     get() = DateFormat.getDateTimeInstance(

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ConfigManager.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ConfigManager.kt
@@ -6,6 +6,7 @@ package com.algoritmico.passepartout.business.managers
 
 import com.algoritmico.passepartout.business.extensions.JSON
 import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
+import com.algoritmico.passepartout.context.AndroidConstants
 import com.algoritmico.passepartout.context.AppLog
 import com.algoritmico.passepartout.context.newEventFlow
 import com.algoritmico.passepartout.models.ConfigBundleConfig
@@ -31,13 +32,14 @@ sealed class ConfigManagerException: Exception() {
 class ConfigManager(
     private val logTag: String,
     private val strategy: ConfigManagerStrategy,
-    private val buildNumber: Int = Int.MAX_VALUE
+    private val buildNumber: Int = Int.MAX_VALUE,
+    eventConstants: AndroidConstants.Events
 ) {
     private val refreshMutex = Mutex()
     private val bundleLock = Any()
     private var bundle: ConfigBundle? = null
 
-    private val _events = newEventFlow()
+    private val _events = newEventFlow(eventConstants)
     val events: SharedFlow<Event> = _events.asSharedFlow()
 
     suspend fun refreshBundle(): Boolean {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ProfileManager.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/ProfileManager.kt
@@ -9,6 +9,7 @@ import com.algoritmico.passepartout.PassepartoutWrapper
 import com.algoritmico.passepartout.business.extensions.JSON
 import com.algoritmico.passepartout.business.extensions.fingerprint
 import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
+import com.algoritmico.passepartout.context.AndroidConstants
 import com.algoritmico.passepartout.context.newEventFlow
 import com.algoritmico.passepartout.models.AppProfileHeader
 import com.algoritmico.passepartout.models.Event
@@ -41,10 +42,11 @@ class ProfileManager(
     private val logTag: String,
     private val library: PassepartoutWrapper,
     private val repository: ProfileRepository,
+    eventConstants: AndroidConstants.Events
 ) {
     private var profiles: Map<String, TaggedProfile> = emptyMap()
 
-    private val _events = newEventFlow()
+    private val _events = newEventFlow(eventConstants)
     val events: SharedFlow<Event> = _events.asSharedFlow()
 
     suspend fun loadInitialProfiles(reportError: (Throwable) -> Unit) {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/VersionChecker.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/business/managers/VersionChecker.kt
@@ -15,6 +15,7 @@ import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.business.extensions.toSemanticVersionOrNull
 import com.algoritmico.passepartout.business.extensions.updateLastCheckedVersion
 import com.algoritmico.passepartout.business.extensions.versionString
+import com.algoritmico.passepartout.context.AndroidConstants
 import com.algoritmico.passepartout.context.newEventFlow
 import com.algoritmico.passepartout.models.ChangelogEntry
 import com.algoritmico.passepartout.models.Event
@@ -50,7 +51,8 @@ class VersionChecker(
     coroutineScope: CoroutineScope,
     private val strategy: VersionCheckerStrategy = DummyVersionCheckerStrategy(),
     currentVersion: String = "255.255.255",
-    private val downloadURL: String = "http://"
+    private val downloadURL: String = "http://",
+    eventConstants: AndroidConstants.Events
 ) : Closeable {
     private val mutex = Mutex()
     private val scope = CoroutineScope(
@@ -60,7 +62,7 @@ class VersionChecker(
         .map { VersionSnapshotState.Ready(it) }
         .stateIn(scope, SharingStarted.Eagerly, VersionSnapshotState.Loading)
     private val currentVersion = currentVersion.toSemanticVersionOrNull() ?: SemanticVersion.max
-    private val _events = newEventFlow()
+    private val _events = newEventFlow(eventConstants)
     val events: SharedFlow<Event> = _events.asSharedFlow()
 
     val latestRelease: VersionRelease?

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/AndroidConstants.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/AndroidConstants.kt
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+package com.algoritmico.passepartout.context
+
+data class AndroidConstants(
+    val assets: Assets = Assets(),
+    val diagnostics: Diagnostics = Diagnostics(),
+    val events: Events = Events(),
+    val logTags: LogTags = LogTags(),
+    val profileImport: ProfileImport = ProfileImport(),
+    val storage: Storage = Storage(),
+    val tunnel: Tunnel = Tunnel()
+) {
+    data class Assets(
+        val constantsFilename: String = "constants.json",
+        val creditsFilename: String = "credits.json"
+    )
+
+    data class Diagnostics(
+        val logcatTimeoutSeconds: Int = 3,
+        val logcatViewHours: Long = 6L,
+        val logcatDestroyTimeoutMillis: Long = 500L,
+        val exitReasonsFilename: String = "exit-reasons.txt",
+        val exitReasonsLimit: Int = 8,
+        val issueCacheDirectory: String = "issue",
+        val issueLogsClipLabel: String = "Issue logs",
+        val issueEmailChooserTitle: String = "Report issue",
+        val issueEmailMimeType: String = "message/rfc822"
+    ) {
+        val logcatTimeoutMillis: Long
+            get() = (logcatTimeoutSeconds * 1000.0)
+                .toLong()
+                .coerceAtLeast(1L)
+    }
+
+    data class Events(
+        val bufferCapacity: Int = 64,
+        val replay: Int = 64
+    )
+
+    data class LogTags(
+        val app: String = "Passepartout",
+        val appPartout: String = "PartoutApp",
+        val service: String = "PassepartoutVpnService",
+        val servicePartout: String = "PartoutService",
+        val partoutJni: String = "PartoutJNI",
+        val outOfBand: String = "PassepartoutOOB"
+    ) {
+        val appTags: Collection<String>
+            get() = listOf(app, appPartout)
+
+        val serviceTags: Collection<String>
+            get() = listOf(service, servicePartout, partoutJni)
+    }
+
+    data class ProfileImport(
+        val mimeTypes: List<String> = listOf(
+            "application/x-openvpn-profile",
+            "application/x-wireguard-profile",
+            "application/octet-stream",
+            "text/*",
+            "*/*"
+        ),
+        val defaultProfileName: String = "Imported profile"
+    )
+
+    data class Storage(
+        val tunnelProfileFilename: String = "tunnel_profile.json",
+        val tunnelPreferencesFilename: String = "tunnel_preferences.json",
+        val preferencesStoreName: String = "preferences"
+    )
+
+    data class Tunnel(
+        val logsSnapshots: Boolean = false,
+        val isForeground: Boolean = true
+    )
+}
+
+val defaultAndroidConstants = AndroidConstants()

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/AndroidConstants.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/AndroidConstants.kt
@@ -8,9 +8,9 @@ data class AndroidConstants(
     val assets: Assets = Assets(),
     val diagnostics: Diagnostics = Diagnostics(),
     val events: Events = Events(),
-    val logTags: LogTags = LogTags(),
     val profileImport: ProfileImport = ProfileImport(),
     val storage: Storage = Storage(),
+    val tags: Tags = Tags(),
     val tunnel: Tunnel = Tunnel()
 ) {
     data class Assets(
@@ -39,7 +39,7 @@ data class AndroidConstants(
         val replay: Int = 64
     )
 
-    data class LogTags(
+    data class Tags(
         val app: String = "Passepartout",
         val appPartout: String = "PartoutApp",
         val service: String = "PassepartoutVpnService",

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/AndroidConstants.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/AndroidConstants.kt
@@ -25,8 +25,6 @@ data class AndroidConstants(
         val exitReasonsFilename: String = "exit-reasons.txt",
         val exitReasonsLimit: Int = 8,
         val issueCacheDirectory: String = "issue",
-        val issueLogsClipLabel: String = "Issue logs",
-        val issueEmailChooserTitle: String = "Report issue",
         val issueEmailMimeType: String = "message/rfc822"
     ) {
         val logcatTimeoutMillis: Long
@@ -62,8 +60,7 @@ data class AndroidConstants(
             "application/octet-stream",
             "text/*",
             "*/*"
-        ),
-        val defaultProfileName: String = "Imported profile"
+        )
     )
 
     data class Storage(

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/AndroidConstants.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/AndroidConstants.kt
@@ -21,6 +21,7 @@ data class AndroidConstants(
     data class Diagnostics(
         val logcatTimeoutSeconds: Int = 3,
         val logcatViewHours: Long = 6L,
+        val logcatLevel: String = "I",
         val logcatDestroyTimeoutMillis: Long = 500L,
         val exitReasonsFilename: String = "exit-reasons.txt",
         val exitReasonsLimit: Int = 8,

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/ContextExtensions.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/ContextExtensions.kt
@@ -11,17 +11,13 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.PreferenceDataStoreFactory
-import androidx.datastore.preferences.preferencesDataStoreFile
+import androidx.datastore.preferences.preferencesDataStore
 import com.algoritmico.passepartout.business.extensions.JSON
 import com.algoritmico.passepartout.business.extensions.versionString
 import com.algoritmico.passepartout.models.AppBundle
 import com.algoritmico.passepartout.models.AppConstants
 import com.algoritmico.passepartout.models.Credits
 import com.algoritmico.passepartout.models.DistributionTarget
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import java.io.File
 
 data class AndroidSystemInformation(
@@ -120,20 +116,9 @@ fun Context.lastTunnelPreferences(storage: AndroidConstants.Storage): File {
     return persistentFile(storage.tunnelPreferencesFilename)
 }
 
-fun Context.userPreferencesStore(storage: AndroidConstants.Storage): DataStore<Preferences> {
-    val appContext = applicationContext
-    val key = "${appContext.packageName}:${storage.preferencesStoreName}"
-    return synchronized(userPreferencesStores) {
-        userPreferencesStores.getOrPut(key) {
-            PreferenceDataStoreFactory.create(
-                scope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
-                produceFile = {
-                    appContext.preferencesDataStoreFile(storage.preferencesStoreName)
-                }
-            )
-        }
-    }
-}
+val Context.userPreferencesStore: DataStore<Preferences> by preferencesDataStore(
+    defaultAndroidConstants.storage.preferencesStoreName
+)
 
 val Context.isBetaSuggestedByAndroidAPI: Boolean
     get() = (applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
@@ -145,5 +130,3 @@ fun Context.persistentFile(path: String): File {
 private fun Context.readAsset(name: String): String {
     return assets.open(name).bufferedReader().use { it.readText() }
 }
-
-private val userPreferencesStores = mutableMapOf<String, DataStore<Preferences>>()

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/ContextExtensions.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/ContextExtensions.kt
@@ -11,35 +11,31 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.preferencesDataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.preferencesDataStoreFile
 import com.algoritmico.passepartout.business.extensions.JSON
 import com.algoritmico.passepartout.business.extensions.versionString
 import com.algoritmico.passepartout.models.AppBundle
 import com.algoritmico.passepartout.models.AppConstants
 import com.algoritmico.passepartout.models.Credits
 import com.algoritmico.passepartout.models.DistributionTarget
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import java.io.File
-
-private object Storage {
-    const val CONSTANTS_FILENAME = "constants.json"
-    const val CREDITS_FILENAME = "credits.json"
-    const val TUNNEL_PROFILE_FILENAME = "tunnel_profile.json"
-    const val TUNNEL_PREFERENCES_FILENAME = "tunnel_preferences.json"
-    const val PREFERENCES_STORE_NAME = "preferences"
-}
 
 data class AndroidSystemInformation(
     val osLine: String,
     val deviceLine: String?
 )
 
-fun Context.appConstants(): AppConstants {
-    val json = readAsset(Storage.CONSTANTS_FILENAME)
+fun Context.appConstants(assets: AndroidConstants.Assets): AppConstants {
+    val json = readAsset(assets.constantsFilename)
     return JSON.decode<AppConstants>(json)
 }
 
-fun Context.credits(): Credits {
-    val json = readAsset(Storage.CREDITS_FILENAME)
+fun Context.credits(assets: AndroidConstants.Assets): Credits {
+    val json = readAsset(assets.creditsFilename)
     return JSON.decode<Credits>(json)
 }
 
@@ -116,15 +112,28 @@ private fun Context.packageInfo(): PackageInfo {
     }
 }
 
-val Context.lastTunnelProfile: File
-    get() = persistentFile(Storage.TUNNEL_PROFILE_FILENAME)
+fun Context.lastTunnelProfile(storage: AndroidConstants.Storage): File {
+    return persistentFile(storage.tunnelProfileFilename)
+}
 
-val Context.lastTunnelPreferences: File
-    get() = persistentFile(Storage.TUNNEL_PREFERENCES_FILENAME)
+fun Context.lastTunnelPreferences(storage: AndroidConstants.Storage): File {
+    return persistentFile(storage.tunnelPreferencesFilename)
+}
 
-val Context.userPreferencesStore: DataStore<Preferences> by preferencesDataStore(
-    Storage.PREFERENCES_STORE_NAME
-)
+fun Context.userPreferencesStore(storage: AndroidConstants.Storage): DataStore<Preferences> {
+    val appContext = applicationContext
+    val key = "${appContext.packageName}:${storage.preferencesStoreName}"
+    return synchronized(userPreferencesStores) {
+        userPreferencesStores.getOrPut(key) {
+            PreferenceDataStoreFactory.create(
+                scope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+                produceFile = {
+                    appContext.preferencesDataStoreFile(storage.preferencesStoreName)
+                }
+            )
+        }
+    }
+}
 
 val Context.isBetaSuggestedByAndroidAPI: Boolean
     get() = (applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
@@ -136,3 +145,5 @@ fun Context.persistentFile(path: String): File {
 private fun Context.readAsset(name: String): String {
     return assets.open(name).bufferedReader().use { it.readText() }
 }
+
+private val userPreferencesStores = mutableMapOf<String, DataStore<Preferences>>()

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/Dependencies.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/context/Dependencies.kt
@@ -27,52 +27,11 @@ import io.partout.PartoutTunnel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 
-//region Constants
-object Tags {
-    val appTags: Collection<String>
-        get() = listOf(APP, APP_PARTOUT)
-
-    val serviceTags: Collection<String>
-        get() = listOf(SERVICE, SERVICE_PARTOUT, PARTOUT_JNI)
-
-    const val APP = "Passepartout"
-    const val APP_PARTOUT = "PartoutApp"
-    const val SERVICE = "PassepartoutVpnService"
-    const val SERVICE_PARTOUT = "PartoutService"
-    const val PARTOUT_JNI = "PartoutJNI"
-    const val OOB = "PassepartoutOOB"
-}
-
-object Files {
-    val MIME_TYPES = arrayOf(
-        "application/x-openvpn-profile",
-        "application/x-wireguard-profile",
-        "application/octet-stream",
-        "text/*",
-        "*/*"
-    )
-
-    const val DEFAULT_PROFILE_NAME = "Imported profile"
-}
-
-object LocalConstants {
-    const val TUNNEL_LOGS_SNAPSHOTS = false
-    const val TUNNEL_IS_FOREGROUND = true
-    const val LOGCAT_TIMEOUT_SECONDS = 3
-    const val LOGCAT_VIEW_HOURS = 6L
-    const val LOGCAT_DESTROY_TIMEOUT_MILLIS = 500L
-}
-
-private object Tuning {
-    const val EVENT_BUFFER_CAPACITY = 64
-    const val EVENT_REPLAY = 64
-}
-//endregion
-
 //region Managers
 fun AppConfiguration.newConfigManager(
     logTag: String,
-    isBeta: Boolean
+    isBeta: Boolean,
+    eventConstants: AndroidConstants.Events
 ): ConfigManager {
     val url = if (isBeta) constants.websites.betaConfigURL else constants.websites.configURL
     val ttlFactor = if (isBeta) constants.websites.betaTTLFactor else 1.0
@@ -89,14 +48,16 @@ fun AppConfiguration.newConfigManager(
                 URLFetcher.fetch(url, isCached, timeout)
             }
         ),
-        buildNumber = bundle.buildNumber
+        buildNumber = bundle.buildNumber,
+        eventConstants = eventConstants
     )
 }
 
 fun AppConfiguration.newProfileManager(
     logTag: String,
     applicationContext: Context,
-    library: PassepartoutWrapper
+    library: PassepartoutWrapper,
+    eventConstants: AndroidConstants.Events
 ): ProfileManager {
     val localName = constants.containers.local.lowercase()
     val directory = applicationContext.persistentFile(localName)
@@ -106,21 +67,23 @@ fun AppConfiguration.newProfileManager(
     return ProfileManager(
         logTag,
         library,
-        FileProfileRepository(logTag, directory)
+        FileProfileRepository(logTag, directory),
+        eventConstants = eventConstants
     )
 }
 
 fun AppConfiguration.newTunnel(
     logTag: String,
     applicationContext: Context,
+    tunnelConstants: AndroidConstants.Tunnel,
     requestVpnPermission: (Intent) -> Unit
 ): PartoutTunnel {
     return PartoutTunnel(
         logTag,
         applicationContext,
         PassepartoutVpnService::class.java,
-        LocalConstants.TUNNEL_IS_FOREGROUND,
-        LocalConstants.TUNNEL_LOGS_SNAPSHOTS,
+        tunnelConstants.isForeground,
+        tunnelConstants.logsSnapshots,
         requestVpnPermission
     )
 }
@@ -128,7 +91,8 @@ fun AppConfiguration.newTunnel(
 fun AppConfiguration.newVersionChecker(
     logTag: String,
     preferences: DataStore<Preferences>,
-    coroutineScope: CoroutineScope
+    coroutineScope: CoroutineScope,
+    eventConstants: AndroidConstants.Events
 ): VersionChecker {
     val changelogURL = constants.github::urlForChangelog
     val isCached = false
@@ -151,14 +115,18 @@ fun AppConfiguration.newVersionChecker(
             DistributionTarget.appStore -> constants.websites.appStoreDownloadURL
             DistributionTarget.developerID -> constants.websites.macDownloadURL
             DistributionTarget.enterprise -> error("No URL for enterprise distribution")
-        }
+        },
+        eventConstants = eventConstants
     )
 }
 
-fun newEventFlow(withReplay: Boolean = true): MutableSharedFlow<Event> {
+fun newEventFlow(
+    eventConstants: AndroidConstants.Events,
+    withReplay: Boolean = true
+): MutableSharedFlow<Event> {
     return MutableSharedFlow(
-        replay = if (withReplay) Tuning.EVENT_REPLAY else 0,
-        extraBufferCapacity = Tuning.EVENT_BUFFER_CAPACITY
+        replay = if (withReplay) eventConstants.replay else 0,
+        extraBufferCapacity = eventConstants.bufferCapacity
     )
 }
 //endregion

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
@@ -7,8 +7,9 @@ import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.business.managers.ConfigManager
 import com.algoritmico.passepartout.business.managers.ProfileManager
 import com.algoritmico.passepartout.business.managers.VersionChecker
+import com.algoritmico.passepartout.context.AndroidConstants
 import com.algoritmico.passepartout.context.AppLog
-import com.algoritmico.passepartout.context.Tags
+import com.algoritmico.passepartout.context.defaultAndroidConstants
 import com.algoritmico.passepartout.context.appBundle
 import com.algoritmico.passepartout.context.appConstants
 import com.algoritmico.passepartout.context.isBetaSuggestedByAndroidAPI
@@ -30,6 +31,7 @@ class AppContext(
     private val logTag: String,
     context: Context,
     private val coroutineScope: CoroutineScope,
+    val androidConstants: AndroidConstants = defaultAndroidConstants,
     requestVpnPermission: (Intent) -> Unit
 ) : Closeable {
     private val applicationContext = context.applicationContext
@@ -58,19 +60,20 @@ class AppContext(
         AppLog.i(logTag, "Partout $partoutVersion")
 
         // User preferences
+        val userPreferencesStore = applicationContext.userPreferencesStore(androidConstants.storage)
         userPreferencesObservable = UserPreferencesObservable(
             logTag,
             coroutineScope,
-            applicationContext.userPreferencesStore
+            userPreferencesStore
         )
         val preferences = userPreferencesObservable.currentPreferences
         AppLog.i(logTag, "Preferences: $preferences")
-        library.partoutInit(Tags.APP_PARTOUT, preferences.logsPrivateData)
+        library.partoutInit(androidConstants.logTags.appPartout, preferences.logsPrivateData)
 
         // Static app configuration
         val bundle = applicationContext.appBundle()
         AppLog.d(logTag, "Bundle: $bundle")
-        val constants = applicationContext.appConstants()
+        val constants = applicationContext.appConstants(androidConstants.assets)
         AppLog.d(logTag, "Constants: $constants")
         appConfiguration = AppConfiguration(
             bundle = bundle,
@@ -84,30 +87,37 @@ class AppContext(
         val tunnel = appConfiguration.newTunnel(
             logTag,
             applicationContext,
+            androidConstants.tunnel,
             requestVpnPermission
         )
         configManager = appConfiguration.newConfigManager(
             logTag,
-            isBeta
+            isBeta,
+            androidConstants.events
         )
         profileManager = appConfiguration.newProfileManager(
             logTag,
             applicationContext,
-            library
+            library,
+            androidConstants.events
         )
         versionChecker = appConfiguration.newVersionChecker(
             logTag,
-            context.userPreferencesStore,
-            coroutineScope
+            userPreferencesStore,
+            coroutineScope,
+            androidConstants.events
         )
 
         // Observables from managers
-        errorHandler = ErrorHandler
+        errorHandler = ErrorHandler(androidConstants.logTags.app)
         configObservable = ConfigObservable(
             configManager,
             coroutineScope
         )
-        diagnosticsObservable = DiagnosticsObservable()
+        diagnosticsObservable = DiagnosticsObservable(
+            logTags = androidConstants.logTags,
+            diagnosticsConstants = androidConstants.diagnostics
+        )
         profileObservable = ProfileObservable(
             profileManager,
             coroutineScope,
@@ -118,13 +128,15 @@ class AppContext(
             applicationContext,
             coroutineScope,
             profileManager,
+            androidConstants.profileImport,
+            errorHandler,
             onImportSuccess = ::onApplicationActive
         )
         tunnelObservable = TunnelObservable(
             logTag,
             tunnel,
             profileManager,
-            context.userPreferencesStore.data,
+            userPreferencesStore.data,
             coroutineScope
         )
         versionObservable = VersionObservable(

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
@@ -69,7 +69,7 @@ class AppContext(
         )
         val preferences = userPreferencesObservable.currentPreferences
         AppLog.i(logTag, "Preferences: $preferences")
-        library.partoutInit(androidConstants.logTags.appPartout, preferences.logsPrivateData)
+        library.partoutInit(androidConstants.tags.appPartout, preferences.logsPrivateData)
 
         // Static app configuration
         val bundle = applicationContext.appBundle()
@@ -110,13 +110,13 @@ class AppContext(
         )
 
         // Observables from managers
-        errorHandler = ErrorHandler(androidConstants.logTags.app)
+        errorHandler = ErrorHandler(androidConstants.tags.app)
         configObservable = ConfigObservable(
             configManager,
             coroutineScope
         )
         diagnosticsObservable = DiagnosticsObservable(
-            logTags = androidConstants.logTags,
+            tags = androidConstants.tags,
             diagnosticsConstants = androidConstants.diagnostics
         )
         profileObservable = ProfileObservable(

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
@@ -2,6 +2,7 @@ package com.algoritmico.passepartout.observables
 
 import android.content.Context
 import android.content.Intent
+import com.algoritmico.passepartout.R
 import com.algoritmico.passepartout.PassepartoutWrapper
 import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.business.managers.ConfigManager
@@ -128,7 +129,7 @@ class AppContext(
             applicationContext,
             coroutineScope,
             profileManager,
-            androidConstants.profileImport,
+            applicationContext.getString(R.string.placeholders_profile_imported_name),
             errorHandler,
             onImportSuccess = ::onApplicationActive
         )

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/AppContext.kt
@@ -61,7 +61,7 @@ class AppContext(
         AppLog.i(logTag, "Partout $partoutVersion")
 
         // User preferences
-        val userPreferencesStore = applicationContext.userPreferencesStore(androidConstants.storage)
+        val userPreferencesStore = applicationContext.userPreferencesStore
         userPreferencesObservable = UserPreferencesObservable(
             logTag,
             coroutineScope,

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/DiagnosticsObservable.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/DiagnosticsObservable.kt
@@ -23,6 +23,7 @@ import com.algoritmico.passepartout.context.androidSystemInformation
 import com.algoritmico.passepartout.models.AppConfiguration
 import com.algoritmico.passepartout.models.Issue
 import com.algoritmico.passepartout.models.IssueAttachment
+import com.algoritmico.passepartout.ui.Strings
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -187,7 +188,7 @@ private fun Context.openIssueEmail(
             clipData = attachments.toClipData(this@openIssueEmail, diagnosticsConstants)
         }
     }
-    startActivity(Intent.createChooser(intent, diagnosticsConstants.issueEmailChooserTitle))
+    startActivity(Intent.createChooser(intent, Strings.Unlocalized.Issues.emailChooserTitle))
 }
 
 private fun Issue.attachmentUris(
@@ -221,7 +222,7 @@ private fun List<Uri>.toClipData(
     diagnosticsConstants: AndroidConstants.Diagnostics
 ): ClipData? {
     val first = firstOrNull() ?: return null
-    return ClipData.newUri(context.contentResolver, diagnosticsConstants.issueLogsClipLabel, first).apply {
+    return ClipData.newUri(context.contentResolver, Strings.Unlocalized.Issues.logsClipLabel, first).apply {
         drop(1).forEach {
             addItem(ClipData.Item(it))
         }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/DiagnosticsObservable.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/DiagnosticsObservable.kt
@@ -36,7 +36,7 @@ import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 class DiagnosticsObservable(
-    private val logTags: AndroidConstants.LogTags,
+    private val tags: AndroidConstants.Tags,
     private val diagnosticsConstants: AndroidConstants.Diagnostics
 ) {
     suspend fun issue(
@@ -46,11 +46,11 @@ class DiagnosticsObservable(
     ): Issue = coroutineScope {
         val appContext = context.applicationContext
         val appLog = async {
-            logcat(logTags.appTags, diagnosticsConstants.logcatViewHours)
+            logcat(tags.appTags, diagnosticsConstants.logcatViewHours)
                 .toIssueAttachment(appConfiguration.appLogPath)
         }
         val tunnelLog = async {
-            logcat(logTags.serviceTags, diagnosticsConstants.logcatViewHours)
+            logcat(tags.serviceTags, diagnosticsConstants.logcatViewHours)
                 .toIssueAttachment(appConfiguration.tunnelLogPath)
         }
         val exitReasons = async(Dispatchers.IO) {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/DiagnosticsObservable.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/DiagnosticsObservable.kt
@@ -154,7 +154,7 @@ class DiagnosticsObservable(
             "-v",
             "time"
         ) + tags.map {
-            "$it:I" // INFO
+            "$it:${diagnosticsConstants.logcatLevel}"
         } + "*:S"
     }
 

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/DiagnosticsObservable.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/DiagnosticsObservable.kt
@@ -18,8 +18,7 @@ import com.algoritmico.passepartout.business.extensions.issues
 import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.business.extensions.subject
 import com.algoritmico.passepartout.business.extensions.versionString
-import com.algoritmico.passepartout.context.LocalConstants
-import com.algoritmico.passepartout.context.Tags
+import com.algoritmico.passepartout.context.AndroidConstants
 import com.algoritmico.passepartout.context.androidSystemInformation
 import com.algoritmico.passepartout.models.AppConfiguration
 import com.algoritmico.passepartout.models.Issue
@@ -35,7 +34,10 @@ import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 
-class DiagnosticsObservable {
+class DiagnosticsObservable(
+    private val logTags: AndroidConstants.LogTags,
+    private val diagnosticsConstants: AndroidConstants.Diagnostics
+) {
     suspend fun issue(
         context: Context,
         appConfiguration: AppConfiguration,
@@ -43,15 +45,15 @@ class DiagnosticsObservable {
     ): Issue = coroutineScope {
         val appContext = context.applicationContext
         val appLog = async {
-            logcat(Tags.appTags, LocalConstants.LOGCAT_VIEW_HOURS)
+            logcat(logTags.appTags, diagnosticsConstants.logcatViewHours)
                 .toIssueAttachment(appConfiguration.appLogPath)
         }
         val tunnelLog = async {
-            logcat(Tags.serviceTags, LocalConstants.LOGCAT_VIEW_HOURS)
+            logcat(logTags.serviceTags, diagnosticsConstants.logcatViewHours)
                 .toIssueAttachment(appConfiguration.tunnelLogPath)
         }
         val exitReasons = async(Dispatchers.IO) {
-            appContext.exitReasonsAttachment()
+            appContext.exitReasonsAttachment(diagnosticsConstants)
         }
         val systemInformation = context.androidSystemInformation()
         Issue(
@@ -81,12 +83,13 @@ class DiagnosticsObservable {
             comment = comment
         )
         val attachments = withContext(Dispatchers.IO) {
-            report.attachmentUris(context)
+            report.attachmentUris(context, diagnosticsConstants)
         }
         context.openIssueEmail(
             appConfiguration = appConfiguration,
             issue = report,
-            attachments = attachments
+            attachments = attachments,
+            diagnosticsConstants = diagnosticsConstants
         )
     }
 
@@ -111,7 +114,7 @@ class DiagnosticsObservable {
             }
             if (!didFinish) {
                 process.destroy()
-                if (!process.waitFor(LocalConstants.LOGCAT_DESTROY_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
+                if (!process.waitFor(diagnosticsConstants.logcatDestroyTimeoutMillis, TimeUnit.MILLISECONDS)) {
                     process.destroyForcibly()
                 }
                 error("logcat timed out")
@@ -134,9 +137,7 @@ class DiagnosticsObservable {
     }
 
     private val logTimeoutMillis: Long
-        get() = (LocalConstants.LOGCAT_TIMEOUT_SECONDS * 1000.0)
-            .toLong()
-            .coerceAtLeast(1L)
+        get() = diagnosticsConstants.logcatTimeoutMillis
 
     private fun logcatCommand(
         tags: Collection<String>,
@@ -172,30 +173,37 @@ class DiagnosticsObservable {
 private fun Context.openIssueEmail(
     appConfiguration: AppConfiguration,
     issue: Issue,
-    attachments: List<Uri>
+    attachments: List<Uri>,
+    diagnosticsConstants: AndroidConstants.Diagnostics
 ) {
     val intent = Intent(Intent.ACTION_SEND_MULTIPLE).apply {
-        type = "message/rfc822"
+        type = diagnosticsConstants.issueEmailMimeType
         putExtra(Intent.EXTRA_EMAIL, arrayOf(appConfiguration.constants.emails.issues))
         putExtra(Intent.EXTRA_SUBJECT, issue.subject)
         putExtra(Intent.EXTRA_TEXT, issue.body)
         if (attachments.isNotEmpty()) {
             putParcelableArrayListExtra(Intent.EXTRA_STREAM, ArrayList(attachments))
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            clipData = attachments.toClipData(this@openIssueEmail)
+            clipData = attachments.toClipData(this@openIssueEmail, diagnosticsConstants)
         }
     }
-    startActivity(Intent.createChooser(intent, "Report issue"))
+    startActivity(Intent.createChooser(intent, diagnosticsConstants.issueEmailChooserTitle))
 }
 
-private fun Issue.attachmentUris(context: Context): List<Uri> {
+private fun Issue.attachmentUris(
+    context: Context,
+    diagnosticsConstants: AndroidConstants.Diagnostics
+): List<Uri> {
     return attachments.map {
-        it.toAttachmentUri(context)
+        it.toAttachmentUri(context, diagnosticsConstants)
     }
 }
 
-private fun IssueAttachment.toAttachmentUri(context: Context): Uri {
-    val directory = File(context.cacheDir, "issue").apply {
+private fun IssueAttachment.toAttachmentUri(
+    context: Context,
+    diagnosticsConstants: AndroidConstants.Diagnostics
+): Uri {
+    val directory = File(context.cacheDir, diagnosticsConstants.issueCacheDirectory).apply {
         mkdirs()
     }
     val file = File(directory, File(filename).name).apply {
@@ -208,9 +216,12 @@ private fun IssueAttachment.toAttachmentUri(context: Context): Uri {
     )
 }
 
-private fun List<Uri>.toClipData(context: Context): ClipData? {
+private fun List<Uri>.toClipData(
+    context: Context,
+    diagnosticsConstants: AndroidConstants.Diagnostics
+): ClipData? {
     val first = firstOrNull() ?: return null
-    return ClipData.newUri(context.contentResolver, "Issue logs", first).apply {
+    return ClipData.newUri(context.contentResolver, diagnosticsConstants.issueLogsClipLabel, first).apply {
         drop(1).forEach {
             addItem(ClipData.Item(it))
         }
@@ -223,25 +234,23 @@ private val AppConfiguration.appLogPath: String
 private val AppConfiguration.tunnelLogPath: String
     get() = constants.log.filenames.tunnel
 
-private const val EXIT_REASONS_FILENAME = "exit-reasons.txt"
-
-private const val EXIT_REASONS_LIMIT = 8
-
 @SuppressLint("NewApi")
-private fun Context.exitReasonsAttachment(): IssueAttachment? {
+private fun Context.exitReasonsAttachment(
+    diagnosticsConstants: AndroidConstants.Diagnostics
+): IssueAttachment? {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
         return null
     }
     val exitReasons = runCatchingNonFatal {
         getSystemService(ActivityManager::class.java)
-            ?.getHistoricalProcessExitReasons(packageName, 0, EXIT_REASONS_LIMIT)
+            ?.getHistoricalProcessExitReasons(packageName, 0, diagnosticsConstants.exitReasonsLimit)
     }.getOrNull()
         ?.takeIf {
             it.isNotEmpty()
         } ?: return null
 
     return IssueAttachment(
-        filename = EXIT_REASONS_FILENAME,
+        filename = diagnosticsConstants.exitReasonsFilename,
         content = exitReasons.toExitReasonsText().toByteArray(Charsets.UTF_8)
     )
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/ErrorHandler.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/ErrorHandler.kt
@@ -8,13 +8,14 @@ import com.algoritmico.passepartout.context.AppLog
 import androidx.compose.ui.platform.UriHandler
 import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.business.extensions.throwIfFatal
-import com.algoritmico.passepartout.context.Tags
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 
-object ErrorHandler {
+class ErrorHandler(
+    private val logTag: String
+) {
     private val _errors = MutableSharedFlow<AppError>(
         replay = 0,
         extraBufferCapacity = 64,
@@ -23,9 +24,13 @@ object ErrorHandler {
     val errors: Flow<AppError> = _errors.asSharedFlow()
 
     fun report(error: Throwable) {
+        report(error, "Unable to complete operation")
+    }
+
+    fun report(error: Throwable, message: String) {
         // This is a guard of last resort to rethrow CancellationException
         error.throwIfFatal()
-        AppLog.e(Tags.APP, "Unable to complete operation", error)
+        AppLog.e(logTag, message, error)
         _errors.tryEmit(error.asAppError)
     }
 }
@@ -34,7 +39,6 @@ fun UriHandler.safeOpenUri(uri: String, handler: ErrorHandler) {
     runCatchingNonFatal {
         openUri(uri)
     }.onFailure {
-        AppLog.e(Tags.APP, "Unable to open URL ($uri)", it)
-        handler.report(it)
+        handler.report(it, "Unable to open URL ($uri)")
     }
 }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/ProfileImporter.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/ProfileImporter.kt
@@ -7,11 +7,11 @@ package com.algoritmico.passepartout.observables
 import android.content.Context
 import android.net.Uri
 import android.provider.OpenableColumns
+import com.algoritmico.passepartout.context.AndroidConstants
 import com.algoritmico.passepartout.context.AppLog
 import com.algoritmico.passepartout.business.extensions.decodeAsTextOrNull
 import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.business.managers.ProfileManager
-import com.algoritmico.passepartout.context.Files
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -28,14 +28,15 @@ class ProfileImporter(
     context: Context,
     private val coroutineScope: CoroutineScope,
     private val profileManager: ProfileManager,
-    private val errorHandler: ErrorHandler = ErrorHandler,
+    private val profileImportConstants: AndroidConstants.ProfileImport,
+    private val errorHandler: ErrorHandler,
     private val onImportSuccess: () -> Unit = {}
 ) {
     private val contentResolver = context.applicationContext.contentResolver
 
     fun importProfile(uri: Uri) {
         coroutineScope.launch {
-            val profileName = displayName(uri) ?: Files.DEFAULT_PROFILE_NAME
+            val profileName = displayName(uri) ?: profileImportConstants.defaultProfileName
             runCatchingNonFatal {
                 val profileText = readProfileText(uri)
                 profileManager.importText(profileText, profileName)

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/ProfileImporter.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/observables/ProfileImporter.kt
@@ -7,7 +7,6 @@ package com.algoritmico.passepartout.observables
 import android.content.Context
 import android.net.Uri
 import android.provider.OpenableColumns
-import com.algoritmico.passepartout.context.AndroidConstants
 import com.algoritmico.passepartout.context.AppLog
 import com.algoritmico.passepartout.business.extensions.decodeAsTextOrNull
 import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
@@ -28,7 +27,7 @@ class ProfileImporter(
     context: Context,
     private val coroutineScope: CoroutineScope,
     private val profileManager: ProfileManager,
-    private val profileImportConstants: AndroidConstants.ProfileImport,
+    private val fallbackProfileName: String,
     private val errorHandler: ErrorHandler,
     private val onImportSuccess: () -> Unit = {}
 ) {
@@ -36,7 +35,7 @@ class ProfileImporter(
 
     fun importProfile(uri: Uri) {
         coroutineScope.launch {
-            val profileName = displayName(uri) ?: profileImportConstants.defaultProfileName
+            val profileName = displayName(uri) ?: fallbackProfileName
             runCatchingNonFatal {
                 val profileText = readProfileText(uri)
                 profileManager.importText(profileText, profileName)

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/AppEnvironment.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/AppEnvironment.kt
@@ -5,6 +5,7 @@
 package com.algoritmico.passepartout.ui
 
 import androidx.compose.runtime.staticCompositionLocalOf
+import com.algoritmico.passepartout.context.AndroidConstants
 import com.algoritmico.passepartout.models.AppConfiguration
 import com.algoritmico.passepartout.observables.ConfigObservable
 import com.algoritmico.passepartout.observables.DiagnosticsObservable
@@ -16,6 +17,10 @@ import com.algoritmico.passepartout.observables.VersionObservable
 
 val LocalAppConfiguration = staticCompositionLocalOf<AppConfiguration> {
     error("No AppConfiguration provided")
+}
+
+val LocalAndroidConstants = staticCompositionLocalOf<AndroidConstants> {
+    error("No AndroidConstants provided")
 }
 
 val LocalConfigObservable = staticCompositionLocalOf<ConfigObservable> {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/PassepartoutApp.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/PassepartoutApp.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import com.algoritmico.passepartout.context.AndroidConstants
 import com.algoritmico.passepartout.observables.AppError
 import com.algoritmico.passepartout.models.AppConfiguration
 import com.algoritmico.passepartout.observables.ConfigObservable
@@ -40,6 +41,7 @@ fun PassepartoutApp(
     diagnosticsObservable: DiagnosticsObservable,
     versionObservable: VersionObservable,
     appConfiguration: AppConfiguration,
+    androidConstants: AndroidConstants,
     errorHandler: ErrorHandler,
     theme: Theme = Theme(),
     onImportProfile: () -> Unit
@@ -51,6 +53,7 @@ fun PassepartoutApp(
     CompositionLocalProvider(
         LocalTheme provides theme,
         LocalAppConfiguration provides appConfiguration,
+        LocalAndroidConstants provides androidConstants,
         LocalConfigObservable provides configObservable,
         LocalDiagnosticsObservable provides diagnosticsObservable,
         LocalProfileObservable provides profileObservable,

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/Strings+Unlocalized.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/Strings+Unlocalized.kt
@@ -59,6 +59,8 @@ object Strings {
         object Issues {
             val subject = "$appName/Android - Report issue"
             const val attachmentMimeType = "text/plain"
+            const val emailChooserTitle = "Report issue"
+            const val logsClipLabel = "Issue logs"
         }
 
         const val appName = "Passepartout"

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/ChangelogView.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/ChangelogView.kt
@@ -52,12 +52,12 @@ fun ChangelogView(
     }
     val theme = LocalTheme.current
 
-    LaunchedEffect(versionNumber, versionObservable, androidConstants.logTags.app) {
+    LaunchedEffect(versionNumber, versionObservable, androidConstants.tags.app) {
         isLoading = true
         entries = runCatchingNonFatal {
             versionObservable.fetchChangelog(versionNumber)
         }.getOrElse {
-            AppLog.w(androidConstants.logTags.app, "Unable to load changelog", it)
+            AppLog.w(androidConstants.tags.app, "Unable to load changelog", it)
             emptyList()
         }
         isLoading = false

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/ChangelogView.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/ChangelogView.kt
@@ -24,9 +24,9 @@ import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.business.extensions.urlForIssue
 import com.algoritmico.passepartout.business.extensions.versionString
 import com.algoritmico.passepartout.context.AppLog
-import com.algoritmico.passepartout.context.Tags
 import com.algoritmico.passepartout.models.ChangelogEntry
 import com.algoritmico.passepartout.observables.safeOpenUri
+import com.algoritmico.passepartout.ui.LocalAndroidConstants
 import com.algoritmico.passepartout.ui.LocalAppConfiguration
 import com.algoritmico.passepartout.ui.LocalErrorHandler
 import com.algoritmico.passepartout.ui.LocalVersionObservable
@@ -40,6 +40,7 @@ import com.algoritmico.passepartout.ui.theme.themeListSection
 fun ChangelogView(
     modifier: Modifier = Modifier
 ) {
+    val androidConstants = LocalAndroidConstants.current
     val appConfiguration = LocalAppConfiguration.current
     val versionObservable = LocalVersionObservable.current
     val versionNumber = appConfiguration.bundle.versionNumber
@@ -51,12 +52,12 @@ fun ChangelogView(
     }
     val theme = LocalTheme.current
 
-    LaunchedEffect(versionNumber, versionObservable) {
+    LaunchedEffect(versionNumber, versionObservable, androidConstants.logTags.app) {
         isLoading = true
         entries = runCatchingNonFatal {
             versionObservable.fetchChangelog(versionNumber)
         }.getOrElse {
-            AppLog.w(Tags.APP, "Unable to load changelog", it)
+            AppLog.w(androidConstants.logTags.app, "Unable to load changelog", it)
             emptyList()
         }
         isLoading = false

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/CreditsView.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/CreditsView.kt
@@ -31,11 +31,11 @@ import androidx.compose.ui.text.font.FontFamily
 import com.algoritmico.passepartout.R
 import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
 import com.algoritmico.passepartout.context.AppLog
-import com.algoritmico.passepartout.context.Tags
 import com.algoritmico.passepartout.context.credits
 import com.algoritmico.passepartout.models.Credits
 import com.algoritmico.passepartout.models.CreditsLicensesInner
 import com.algoritmico.passepartout.models.CreditsNoticesInner
+import com.algoritmico.passepartout.ui.LocalAndroidConstants
 import com.algoritmico.passepartout.ui.theme.LocalTheme
 import com.algoritmico.passepartout.ui.theme.ThemeList
 import com.algoritmico.passepartout.ui.theme.ThemeProgressView
@@ -52,11 +52,12 @@ fun CreditsView(
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
-    val credits = remember(context) {
+    val androidConstants = LocalAndroidConstants.current
+    val credits = remember(context, androidConstants.assets) {
         runCatchingNonFatal {
-            context.credits()
+            context.credits(androidConstants.assets)
         }.getOrElse {
-            AppLog.w(Tags.APP, "Unable to load credits", it)
+            AppLog.w(androidConstants.logTags.app, "Unable to load credits", it)
             Credits(emptyList(), emptyList(), emptyMap())
         }
     }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/CreditsView.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/CreditsView.kt
@@ -57,7 +57,7 @@ fun CreditsView(
         runCatchingNonFatal {
             context.credits(androidConstants.assets)
         }.getOrElse {
-            AppLog.w(androidConstants.logTags.app, "Unable to load credits", it)
+            AppLog.w(androidConstants.tags.app, "Unable to load credits", it)
             Credits(emptyList(), emptyList(), emptyMap())
         }
     }

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/LogcatView.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/LogcatView.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import com.algoritmico.passepartout.R
 import com.algoritmico.passepartout.business.extensions.runCatchingNonFatal
-import com.algoritmico.passepartout.context.LocalConstants
+import com.algoritmico.passepartout.ui.LocalAndroidConstants
 import com.algoritmico.passepartout.ui.LocalDiagnosticsObservable
 import com.algoritmico.passepartout.ui.LocalErrorHandler
 import com.algoritmico.passepartout.ui.theme.LocalTheme
@@ -37,6 +37,7 @@ fun LogcatView(
     modifier: Modifier = Modifier,
     tags: Collection<String>
 ) {
+    val androidConstants = LocalAndroidConstants.current
     val diagnosticsObservable = LocalDiagnosticsObservable.current
     val errorHandler = LocalErrorHandler.current
     val listState = rememberLazyListState()
@@ -47,7 +48,7 @@ fun LogcatView(
     LaunchedEffect(tags) {
         lines = null
         runCatchingNonFatal {
-            diagnosticsObservable.logcat(tags, LocalConstants.LOGCAT_VIEW_HOURS)
+            diagnosticsObservable.logcat(tags, androidConstants.diagnostics.logcatViewHours)
         }.onSuccess {
             lines = it
         }.onFailure {

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/SettingsCoordinator.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/SettingsCoordinator.kt
@@ -108,7 +108,7 @@ private fun PushDestination(
     val androidConstants = LocalAndroidConstants.current
     when (route) {
         SettingsCoordinatorRoute.AppLog -> {
-            LogcatView(tags = androidConstants.logTags.appTags)
+            LogcatView(tags = androidConstants.tags.appTags)
         }
         SettingsCoordinatorRoute.Credits -> CreditsView()
         SettingsCoordinatorRoute.Diagnostics -> {
@@ -126,7 +126,7 @@ private fun PushDestination(
         }
         SettingsCoordinatorRoute.PreferencesAdvanced -> PreferencesAdvancedView()
         SettingsCoordinatorRoute.TunnelLog -> {
-            LogcatView(tags = androidConstants.logTags.serviceTags)
+            LogcatView(tags = androidConstants.tags.serviceTags)
         }
         SettingsCoordinatorRoute.Version -> VersionView()
         null -> PlaceholderDestination(stringResource(R.string.global_nouns_no_selection))

--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/SettingsCoordinator.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/ui/settings/SettingsCoordinator.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.algoritmico.passepartout.R
 import com.algoritmico.passepartout.business.extensions.versionString
-import com.algoritmico.passepartout.context.Tags
+import com.algoritmico.passepartout.ui.LocalAndroidConstants
 import com.algoritmico.passepartout.ui.LocalAppConfiguration
 import com.algoritmico.passepartout.ui.theme.LocalTheme
 import com.algoritmico.passepartout.ui.theme.ThemeNavigatingButton
@@ -105,9 +105,10 @@ private fun PushDestination(
     route: SettingsCoordinatorRoute?,
     onRoute: (SettingsCoordinatorRoute) -> Unit
 ) {
+    val androidConstants = LocalAndroidConstants.current
     when (route) {
         SettingsCoordinatorRoute.AppLog -> {
-            LogcatView(tags = Tags.appTags)
+            LogcatView(tags = androidConstants.logTags.appTags)
         }
         SettingsCoordinatorRoute.Credits -> CreditsView()
         SettingsCoordinatorRoute.Diagnostics -> {
@@ -125,7 +126,7 @@ private fun PushDestination(
         }
         SettingsCoordinatorRoute.PreferencesAdvanced -> PreferencesAdvancedView()
         SettingsCoordinatorRoute.TunnelLog -> {
-            LogcatView(tags = Tags.serviceTags)
+            LogcatView(tags = androidConstants.logTags.serviceTags)
         }
         SettingsCoordinatorRoute.Version -> VersionView()
         null -> PlaceholderDestination(stringResource(R.string.global_nouns_no_selection))


### PR DESCRIPTION
Move all Android-specific constants to a single place and propagate them through the Compose context, rather than hardcoding. Only the preferences store uses the default Android constants for a simpler lifecycle, but everything else is now parametric.