### PR TITLE
WireGuard: Fix editor regression in IPv6 endpoints

### DIFF
--- a/app-apple/Sources/AppLibraryMain/Views/Modules/WireGuard/WireGuardView+Configuration.swift
+++ b/app-apple/Sources/AppLibraryMain/Views/Modules/WireGuard/WireGuardView+Configuration.swift
@@ -225,7 +225,9 @@ extension WireGuardView.ConfigurationView {
                 var peer = Peer()
                 peer.publicKey = $1.publicKey
                 peer.preSharedKey = $1.preSharedKey ?? ""
-                peer.endpoint = $1.endpoint ?? ""
+                peer.endpoint = $1.endpoint.map {
+                    Endpoint(rawValue: $0)?.wgRepresentation ?? $0
+                } ?? ""
                 peer.allowedIPs = $1.allowedIPs.joined(separator: separator)
                 peer.keepAlive = $1.keepAlive?.description ?? ""
                 $0[$1.publicKey] = peer

--- a/app-apple/Tests/AppLibraryMainTests/WireGuardViewModelTests.swift
+++ b/app-apple/Tests/AppLibraryMainTests/WireGuardViewModelTests.swift
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+@testable import AppLibraryMain
+import CommonLibrary
+import Testing
+
+@MainActor
+struct WireGuardViewModelTests {
+    @Test
+    func givenIPv6Endpoint_whenLoadAndSave_thenPreservesSquareBrackets() throws {
+        let publicKey = "peer"
+        var peer = WireGuard.RemoteInterface.Builder(publicKey: publicKey)
+        peer.endpoint = "2001:db8::1:51820"
+
+        var configuration = WireGuard.Configuration.Builder(privateKey: "")
+        configuration.peers = [peer]
+
+        let draft = ModuleDraft(module: WireGuardModule.Builder(configurationBuilder: configuration))
+        var sut = WireGuardView.ConfigurationView.ViewModel()
+
+        sut.load(from: configuration)
+        sut.save(to: draft, fallback: configuration)
+
+        let savedEndpoint = try #require(draft.module.configurationBuilder?.peers.first?.endpoint)
+        #expect(savedEndpoint == "[2001:db8::1]:51820")
+    }
+}

--- a/app-apple/Tests/AppLibraryTests/OnboardingObservableTests.swift
+++ b/app-apple/Tests/AppLibraryTests/OnboardingObservableTests.swift
@@ -53,7 +53,7 @@ struct OnboardingObservableTests {
 
     @Test
     func givenLast_whenAdvance_thenDoesNotAdvance() {
-        let sut = OnboardingObservable(initialStep: .doneV3_5_18)
+        let sut = OnboardingObservable(initialStep: .doneV3_9_5)
         #expect(sut.step == .last)
         sut.advance()
         #expect(sut.step == .doneV3_9_5)

--- a/app-apple/Tests/AppLibraryTests/OnboardingObservableTests.swift
+++ b/app-apple/Tests/AppLibraryTests/OnboardingObservableTests.swift
@@ -56,6 +56,6 @@ struct OnboardingObservableTests {
         let sut = OnboardingObservable(initialStep: .doneV3_5_18)
         #expect(sut.step == .last)
         sut.advance()
-        #expect(sut.step == .doneV3_5_18)
+        #expect(sut.step == .doneV3_9_5)
     }
 }


### PR DESCRIPTION
Fixes #1894