### PR TITLE
Zig: Refactor and fall back to Swift runtime

### DIFF
--- a/app-apple/Passepartout/App/Context/AppContext+Production.swift
+++ b/app-apple/Passepartout/App/Context/AppContext+Production.swift
@@ -39,7 +39,7 @@ extension AppContext {
             with: appConfiguration,
             preferences: preferences,
             localURL: appConfiguration.urlForAppLog,
-            localMapper: logFormatter?.localMapper
+            localMapper: logFormatter.localMapper
         )
         pspLog(.core, .notice, "Partout \(PartoutConstants.version)")
 

--- a/app-apple/Passepartout/Tunnel/PacketTunnelProvider.swift
+++ b/app-apple/Passepartout/Tunnel/PacketTunnelProvider.swift
@@ -8,10 +8,12 @@ import CommonLibrary
 import Partout
 import TunnelLibrary
 
+extension NSObject: @retroactive @unchecked Sendable {}
+
 final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
     private var context: TunnelContextProtocol?
 
-    override func startTunnel(options: [String: NSObject]? = nil, completionHandler: @escaping @Sendable (Error?) -> Void) {
+    override func startTunnel(options: [String: NSObject]? = nil) async throws {
         let distributionTarget: ABI.DistributionTarget
 #if PP_BUILD_MAC
         distributionTarget = .developerID
@@ -33,7 +35,7 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
             with: appConfiguration,
             preferences: AppPreferencesStore(),
             localURL: appConfiguration.urlForTunnelLog,
-            localMapper: logFormatter?.localMapper
+            localMapper: logFormatter.localMapper
         )
         pspLog(.core, .notice, "Partout \(PartoutConstants.version) (Swift)")
 
@@ -55,34 +57,23 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
         let preferences = AppPreferencesStore({
             let persistedPreferences = UserDefaultsAppPreferences(defaults: .standard)
             if let startPreferences {
+                pspLog(.core, .info, "PTP: Decoded preferences: \(startPreferences)")
                 persistedPreferences.copy(startPreferences)
-                pspLog(.core, .debug, "PTP: persistedPreferences: \(persistedPreferences)")
-                pspLog(.core, .debug, "PTP: startPreferences: \(startPreferences)")
                 assert(persistedPreferences.serialized() == startPreferences)
                 return startPreferences
             }
+            pspLog(.core, .info, "PTP: Existing preferences: \(persistedPreferences)")
             return persistedPreferences
         }())
 
         // Create the tunnel context
-        Task { @MainActor in
-            do {
-                // TODO: #218, cachesURL must be per-profile
-                let cachesURL = FileManager.default.temporaryDirectory
-                context = try await TunnelContext.forProduction(
-                    appConfiguration: appConfiguration,
-                    preferences: preferences,
-                    startPreferences: startPreferences,
-                    cachesURL: cachesURL,
-                    neProvider: self
-                )
-                context?.log(.core, .notice, "Start PTP")
-                try await context?.start(isInteractive: isInteractive)
-                completionHandler(nil)
-            } catch {
-                completionHandler(error)
-            }
-        }
+        context = try await TunnelContext.forProduction(
+            neProvider: self,
+            appConfiguration: appConfiguration,
+            preferences: preferences
+        )
+        context?.log(.core, .notice, "Start PTP")
+        try await context?.start(isInteractive: isInteractive)
     }
 
     override func stopTunnel(with reason: NEProviderStopReason) async {

--- a/app-apple/Passepartout/Tunnel/TunnelContext+Production.swift
+++ b/app-apple/Passepartout/Tunnel/TunnelContext+Production.swift
@@ -173,13 +173,10 @@ extension TunnelContext {
         await iapManager.fetchLevelIfNeeded()
         let skipsPurchases = !appConfiguration.bundle.distributionTarget.supportsIAP || preferences[\.skipsPurchases]
         let verificationParameters = appConfiguration.constants.tunnel.verificationParameters(isBeta: iapManager.isBeta)
-        // Relax verification strategy based on AppPreference
-        // Assemble
         let iap = TunnelContext.IAP(
             manager: iapManager,
             skipsPurchases: skipsPurchases,
-            verificationParameters: verificationParameters,
-            usesRelaxedVerification: true
+            verificationParameters: verificationParameters
         )
 
         return TunnelContext(

--- a/app-apple/Passepartout/Tunnel/TunnelContext+Production.swift
+++ b/app-apple/Passepartout/Tunnel/TunnelContext+Production.swift
@@ -11,18 +11,10 @@ import TunnelLibrary
 
 extension TunnelContext {
     public static func forProduction(
+        neProvider: NEPacketTunnelProvider,
         appConfiguration: ABI.AppConfiguration,
-        preferences: AppPreferencesStore,
-        startPreferences: ABI.AppPreferencesProtocol?,
-        // TODO: #218, cachesURL must be per-profile
-        cachesURL: URL,
-        neProvider: NEPacketTunnelProvider
+        preferences: AppPreferencesStore
     ) async throws -> TunnelContext {
-        let backend: TunnelBackendProtocol
-        let originalProfile: Profile
-        let processedProfile: Profile
-        let environment: TunnelEnvironment
-
         guard let bundleIdentifier = Bundle.main.bundleIdentifier else {
             fatalError("Nil .bundleIdentifier?")
         }
@@ -30,134 +22,32 @@ extension TunnelContext {
             .global,
             bundleIdentifier: bundleIdentifier
         )
+        // TODO: #218, cachesURL must be per-profile
+        let cachesURL = FileManager.default.temporaryDirectory
 
-        if preferences.isFlagEnabled(.zigRuntime) {
-            pspLog(.core, .info, "Using Zig runtime (\(PartoutProviderRuntime.version))")
-
-            let appGroup = appConfiguration.bundle.bundleString(for: .groupId)
-            guard let defaults = UserDefaults(suiteName: appGroup) else {
-                fatalError("No access to App Group: \(appGroup)")
+        // Pick runtime based on config flag
+        let runtime = try {
+            if preferences.isFlagEnabled(.zigRuntime) {
+                do {
+                    return try newZigRuntime(
+                        neProvider: neProvider,
+                        appConfiguration: appConfiguration,
+                        preferences: preferences,
+                        keychain: keychain,
+                        cachesURL: cachesURL
+                    )
+                } catch RuntimeError.unsupportedProviders {
+                    // Fall back to Swift
+                }
             }
-            // TODO: #218, cachesURL must be per-profile
-            let cachesURL = FileManager.default.temporaryDirectory
-            // FIXME: ###, Profile decoding requires no registry
-            let registry = appConfiguration.newRegistryForTunnel(
+            return try newSwiftRuntime(
+                neProvider: neProvider,
+                appConfiguration: appConfiguration,
                 preferences: preferences,
+                keychain: keychain,
                 cachesURL: cachesURL
             )
-            let decoder = appConfiguration.newNEProtocolCoder(
-                .global,
-                coder: registry,
-                keychain: keychain
-            )
-            let runtime = try PartoutProviderRuntime(
-                provider: neProvider,
-                decoder: decoder,
-                options: .init(
-                    dnsFallbackServers: appConfiguration.constants.tunnel.dnsFallbackServers,
-                    logsSnapshots: false
-                ),
-                defaults: defaults,
-                logsPrivateData: preferences[\.logsPrivateData],
-                cacheDir: cachesURL.path(),
-                minDataCountDelta: appConfiguration.constants.tunnel.minDataCountDelta,
-                logger: logger
-            )
-            originalProfile = runtime.profile
-            processedProfile = originalProfile
-            environment = appConfiguration.newTunnelEnvironment(profileId: processedProfile.id)
-            backend = runtime
-        } else {
-            pspLog(.core, .info, "Using Swift runtime")
-
-            // Create global registry
-            let registry = appConfiguration.newRegistryForTunnel(
-                preferences: preferences,
-                cachesURL: cachesURL
-            )
-
-            // Decode profile from NE provider
-            do {
-                let decoder = appConfiguration.newNEProtocolCoder(
-                    .global,
-                    coder: registry,
-                    keychain: keychain
-                )
-                originalProfile = try Profile(withNEProvider: neProvider, decoder: decoder)
-                let resolvedProfile = try registry.resolvedProfile(originalProfile)
-                let processor = appConfiguration.newTunnelProcessor()
-                processedProfile = try processor.willProcess(resolvedProfile)
-            } catch {
-                pspLog(.profiles, .fault, "Unable to decode or process profile: \(error)")
-                throw error
-            }
-            environment = appConfiguration.newTunnelEnvironment(profileId: processedProfile.id)
-
-            // Update the logger now that we have a context
-            assert(processedProfile.id == originalProfile.id)
-            let logFormatter = appConfiguration.newLogFormatter()
-            let ctx = pspLogRegister(
-                for: .tunnelProfile(processedProfile.id),
-                with: appConfiguration,
-                preferences: preferences,
-                localURL: appConfiguration.urlForTunnelLog,
-                localMapper: logFormatter?.localMapper
-            )
-
-            // Decode preferences and config flags
-            pspLog(ctx.profileId, .core, .info, "Tunnel profile initialized")
-            if let startPreferences {
-                pspLog(ctx.profileId, .core, .info, "\tDecoded preferences: \(startPreferences)")
-            } else {
-                pspLog(ctx.profileId, .core, .info, "\tExisting preferences: \(preferences)")
-            }
-            let configFlags = preferences[\.configFlags]
-            pspLog(ctx.profileId, .core, .info, "\tActive config flags: \(configFlags)")
-            pspLog(ctx.profileId, .core, .info, "\tIgnored config flags: \(preferences[\.experimental.ignoredConfigFlags])")
-            pspLog(ctx.profileId, .core, .info, "\tEnabled config flags: \(preferences[\.experimental.enabledConfigFlags])")
-
-            // Create TunnelController for connnection management
-            let neTunnelController = NETunnelController(
-                provider: neProvider,
-                profile: processedProfile,
-                options: {
-                    var options = TunnelControllerOptions()
-                    if preferences[\.dnsFallsBack] {
-                        options.dnsFallbackServers = appConfiguration.constants.tunnel.dnsFallbackServers
-                    }
-                    return options
-                }()
-            )
-
-            // Create daemon
-            let factory: NetworkInterfaceFactory
-            if preferences.isFlagEnabled(.ovpnV3) {
-                factory = NativeSocketFactory(ctx, betterPathFactory: NEBetterPathStreamFactory(ctx))
-            } else {
-                let options = NEInterfaceFactory.Options()
-                factory = NEInterfaceFactory(ctx, provider: neProvider, options: options)
-            }
-            let reachability = NEObservablePath(ctx)
-            let connectionOptions = ConnectionParameters.Options()
-            let connectionParameters = ConnectionParameters(
-                profile: processedProfile,
-                controller: neTunnelController,
-                factory: factory,
-                reachability: reachability,
-                environment: environment,
-                options: connectionOptions
-            )
-            let messageHandler = DefaultMessageHandler(ctx, environment: environment)
-            let params = SimpleConnectionDaemon.Parameters(
-                connectionFactory: registry,
-                connectionParameters: connectionParameters,
-                messageHandler: messageHandler,
-                startsImmediately: true,
-                cancelsUnrecoverable: false // Prevents on-demand reconnection
-            )
-            let daemon = try SimpleConnectionDaemon(params: params)
-            backend = daemon
-        }
+        }()
 
         // Create IAPManager for receipt verification
         let iapManager = appConfiguration.newIAPManager(
@@ -180,10 +70,173 @@ extension TunnelContext {
         )
 
         return TunnelContext(
+            backend: runtime.backend,
+            originalProfile: runtime.originalProfile,
+            environment: runtime.environment,
+            iap: iap
+        )
+    }
+}
+
+private extension TunnelContext {
+    struct ProductionRuntime {
+        let backend: TunnelBackendProtocol
+        let originalProfile: Profile
+        let environment: TunnelEnvironment
+    }
+
+    enum RuntimeError: Error {
+        case unsupportedProviders
+    }
+
+    static func newZigRuntime(
+        neProvider: NEPacketTunnelProvider,
+        appConfiguration: ABI.AppConfiguration,
+        preferences: AppPreferencesStore,
+        keychain: Keychain,
+        cachesURL: URL
+    ) throws -> ProductionRuntime {
+        pspLog(.core, .info, "Using Zig runtime (\(PartoutProviderRuntime.version))")
+
+        let appGroup = appConfiguration.bundle.bundleString(for: .groupId)
+        guard let defaults = UserDefaults(suiteName: appGroup) else {
+            fatalError("No access to App Group: \(appGroup)")
+        }
+        // XXX: Profile decoding requires no registry
+        let registry = appConfiguration.newRegistryForTunnel(
+            preferences: preferences,
+            cachesURL: cachesURL
+        )
+        let decoder = appConfiguration.newNEProtocolCoder(
+            .global,
+            coder: registry,
+            keychain: keychain
+        )
+        let backend = try PartoutProviderRuntime(
+            provider: neProvider,
+            decoder: decoder,
+            options: .init(
+                dnsFallbackServers: appConfiguration.constants.tunnel.dnsFallbackServers,
+                logsSnapshots: false
+            ),
+            defaults: defaults,
+            logsPrivateData: preferences[\.logsPrivateData],
+            cacheDir: cachesURL.path(),
+            minDataCountDelta: appConfiguration.constants.tunnel.minDataCountDelta,
+            logger: logger
+        )
+        let originalProfile = backend.profile
+
+        // Profiles with provider modules require the Swift runtime
+        guard originalProfile.activeProviderModule == nil else {
+            pspLog(originalProfile.id, .profiles, .error, "Providers are not supported by Zig, falling back to Swift runtime")
+            throw RuntimeError.unsupportedProviders
+        }
+
+        let environment = appConfiguration.newTunnelEnvironment(profileId: originalProfile.id)
+        return ProductionRuntime(
             backend: backend,
+            originalProfile: originalProfile,
+            environment: environment
+        )
+    }
+
+    static func newSwiftRuntime(
+        neProvider: NEPacketTunnelProvider,
+        appConfiguration: ABI.AppConfiguration,
+        preferences: AppPreferencesStore,
+        keychain: Keychain,
+        cachesURL: URL
+    ) throws -> ProductionRuntime {
+        pspLog(.core, .info, "Using Swift runtime")
+
+        // Create global registry
+        let registry = appConfiguration.newRegistryForTunnel(
+            preferences: preferences,
+            cachesURL: cachesURL
+        )
+
+        // Decode profile from NE provider
+        let originalProfile: Profile
+        let processedProfile: Profile
+        do {
+            let decoder = appConfiguration.newNEProtocolCoder(
+                .global,
+                coder: registry,
+                keychain: keychain
+            )
+            originalProfile = try Profile(withNEProvider: neProvider, decoder: decoder)
+            let resolvedProfile = try registry.resolvedProfile(originalProfile)
+            let processor = appConfiguration.newTunnelProcessor()
+            processedProfile = try processor.willProcess(resolvedProfile)
+        } catch {
+            pspLog(.profiles, .fault, "Unable to decode or process profile: \(error)")
+            throw error
+        }
+        let environment = appConfiguration.newTunnelEnvironment(profileId: processedProfile.id)
+
+        // Update the logger now that we have a context
+        assert(processedProfile.id == originalProfile.id)
+        let logFormatter = appConfiguration.newLogFormatter()
+        let ctx = pspLogRegister(
+            for: .tunnelProfile(processedProfile.id),
+            with: appConfiguration,
+            preferences: preferences,
+            localURL: appConfiguration.urlForTunnelLog,
+            localMapper: logFormatter.localMapper
+        )
+
+        // Decode preferences and config flags
+        pspLog(ctx.profileId, .core, .info, "Tunnel profile initialized")
+        let configFlags = preferences[\.configFlags]
+        pspLog(ctx.profileId, .core, .info, "\tActive config flags: \(configFlags)")
+        pspLog(ctx.profileId, .core, .info, "\tIgnored config flags: \(preferences[\.experimental.ignoredConfigFlags])")
+        pspLog(ctx.profileId, .core, .info, "\tEnabled config flags: \(preferences[\.experimental.enabledConfigFlags])")
+
+        // Create TunnelController for connnection management
+        let neTunnelController = NETunnelController(
+            provider: neProvider,
+            profile: processedProfile,
+            options: {
+                var options = TunnelControllerOptions()
+                if preferences[\.dnsFallsBack] {
+                    options.dnsFallbackServers = appConfiguration.constants.tunnel.dnsFallbackServers
+                }
+                return options
+            }()
+        )
+
+        // Create daemon
+        let factory: NetworkInterfaceFactory
+        if preferences.isFlagEnabled(.ovpnV3) {
+            factory = NativeSocketFactory(ctx, betterPathFactory: NEBetterPathStreamFactory(ctx))
+        } else {
+            let options = NEInterfaceFactory.Options()
+            factory = NEInterfaceFactory(ctx, provider: neProvider, options: options)
+        }
+        let reachability = NEObservablePath(ctx)
+        let connectionOptions = ConnectionParameters.Options()
+        let connectionParameters = ConnectionParameters(
+            profile: processedProfile,
+            controller: neTunnelController,
+            factory: factory,
+            reachability: reachability,
             environment: environment,
-            iap: iap,
-            originalProfile: originalProfile
+            options: connectionOptions
+        )
+        let messageHandler = DefaultMessageHandler(ctx, environment: environment)
+        let params = SimpleConnectionDaemon.Parameters(
+            connectionFactory: registry,
+            connectionParameters: connectionParameters,
+            messageHandler: messageHandler,
+            startsImmediately: true,
+            cancelsUnrecoverable: false // Prevents on-demand reconnection
+        )
+        let backend = try SimpleConnectionDaemon(params: params)
+        return ProductionRuntime(
+            backend: backend,
+            originalProfile: originalProfile,
+            environment: environment
         )
     }
 }

--- a/app-apple/Passepartout/Tunnel/TunnelContext+Production.swift
+++ b/app-apple/Passepartout/Tunnel/TunnelContext+Production.swift
@@ -36,7 +36,8 @@ extension TunnelContext {
                         keychain: keychain,
                         cachesURL: cachesURL
                     )
-                } catch RuntimeError.unsupportedProviders {
+                } catch RuntimeError.undecodableProfile,
+                        RuntimeError.unsupportedProviders {
                     // Fall back to Swift
                 }
             }
@@ -86,6 +87,7 @@ private extension TunnelContext {
     }
 
     enum RuntimeError: Error {
+        case undecodableProfile
         case unsupportedProviders
     }
 
@@ -102,19 +104,25 @@ private extension TunnelContext {
         guard let defaults = UserDefaults(suiteName: appGroup) else {
             fatalError("No access to App Group: \(appGroup)")
         }
-        // XXX: Profile decoding requires no registry
-        let registry = appConfiguration.newRegistryForTunnel(
-            preferences: preferences,
-            cachesURL: cachesURL
-        )
+        // Profile decoding requires no registry. Parse as TaggedProfile
+        // and rethrow on failure.
+        let coder = TaggedProfileCoder()
         let decoder = appConfiguration.newNEProtocolCoder(
             .global,
-            coder: registry,
+            coder: coder,
             keychain: keychain
         )
+        let profile: Profile
+        do {
+            profile = try Profile(withNEProvider: neProvider, decoder: decoder)
+        } catch {
+            pspLog(.profiles, .error, "Unable to decode profile in Zig (legacy?), falling back to Swift runtime: \(error)")
+            throw RuntimeError.undecodableProfile
+        }
+
         let backend = try PartoutProviderRuntime(
             provider: neProvider,
-            decoder: decoder,
+            profile: profile,
             options: .init(
                 dnsFallbackServers: appConfiguration.constants.tunnel.dnsFallbackServers,
                 logsSnapshots: false
@@ -125,18 +133,17 @@ private extension TunnelContext {
             minDataCountDelta: appConfiguration.constants.tunnel.minDataCountDelta,
             logger: logger
         )
-        let originalProfile = backend.profile
 
         // Profiles with provider modules require the Swift runtime
-        guard originalProfile.activeProviderModule == nil else {
-            pspLog(originalProfile.id, .profiles, .error, "Providers are not supported by Zig, falling back to Swift runtime")
+        guard profile.activeProviderModule == nil else {
+            pspLog(profile.id, .profiles, .error, "Providers are not supported by Zig, falling back to Swift runtime")
             throw RuntimeError.unsupportedProviders
         }
 
-        let environment = appConfiguration.newTunnelEnvironment(profileId: originalProfile.id)
+        let environment = appConfiguration.newTunnelEnvironment(profileId: profile.id)
         return ProductionRuntime(
             backend: backend,
-            originalProfile: originalProfile,
+            originalProfile: profile,
             environment: environment
         )
     }
@@ -238,6 +245,16 @@ private extension TunnelContext {
             originalProfile: originalProfile,
             environment: environment
         )
+    }
+}
+
+private struct TaggedProfileCoder: ProfileCoder {
+    func profile(fromString string: String) throws -> Profile {
+        try ABI.decodeJSON(TaggedProfile.self, from: string).asProfile()
+    }
+
+    func string(fromProfile profile: Profile) throws -> String {
+        try ABI.encodeJSON(profile.asTaggedProfile)
     }
 }
 

--- a/app-apple/Sources/CommonLibrary/Dependencies/AppConfiguration+Dependencies.swift
+++ b/app-apple/Sources/CommonLibrary/Dependencies/AppConfiguration+Dependencies.swift
@@ -391,7 +391,7 @@ extension ABI.AppConfiguration {
         }
     }
 
-    public func newLogFormatter() -> LogFormatter? {
+    public func newLogFormatter() -> LogFormatter {
         FoundationLogFormatter(
             dateFormat: constants.log.formatter.timestamp,
             messageFormat: constants.log.formatter.message

--- a/app-apple/Sources/CommonLibraryCore/Business/AppPreferencesStore.swift
+++ b/app-apple/Sources/CommonLibraryCore/Business/AppPreferencesStore.swift
@@ -3,17 +3,12 @@
 // SPDX-License-Identifier: GPL-3.0
 
 public final class AppPreferencesStore: @unchecked Sendable {
-    public typealias RequestBlock = (ABI.AppPreferences, Set<ABI.NonUserFacingAppPreferenceKey>) -> Void
-
     private var backend: ABI.AppPreferencesProtocol
-    public var onRequest: RequestBlock?
 
     public init(
         _ backend: ABI.AppPreferencesProtocol = .default(),
-        onRequest: RequestBlock? = nil
     ) {
         self.backend = backend
-        self.onRequest = onRequest
     }
 }
 

--- a/app-apple/Sources/TunnelLibrary/TunnelContext.swift
+++ b/app-apple/Sources/TunnelLibrary/TunnelContext.swift
@@ -10,18 +10,15 @@ public final class TunnelContext: TunnelContextProtocol {
         let manager: IAPManager
         let skipsPurchases: Bool
         let verificationParameters: ABI.AppConstants.TunnelVerificationParameters
-        let usesRelaxedVerification: Bool
 
         public init(
             manager: IAPManager,
             skipsPurchases: Bool,
-            verificationParameters: ABI.AppConstants.TunnelVerificationParameters,
-            usesRelaxedVerification: Bool
+            verificationParameters: ABI.AppConstants.TunnelVerificationParameters
         ) {
             self.manager = manager
             self.skipsPurchases = skipsPurchases
             self.verificationParameters = verificationParameters
-            self.usesRelaxedVerification = usesRelaxedVerification
         }
     }
 
@@ -84,7 +81,7 @@ public final class TunnelContext: TunnelContextProtocol {
 
             // Prepare for periodic receipt verification
             let params = iap.verificationParameters
-            pspLog(.iap, .info, "Will start profile verification in \(params.delay) seconds (\(iap.usesRelaxedVerification ? "relaxed" : "strict"))")
+            pspLog(.iap, .info, "Will start profile verification in \(params.delay) seconds")
 
             // Do not wait for this to start the tunnel. If on-demand is
             // enabled, networking will stall and StoreKit network calls may
@@ -97,8 +94,7 @@ public final class TunnelContext: TunnelContextProtocol {
                     of: originalProfile,
                     iapManager: iap.manager,
                     environment: environment,
-                    params: params,
-                    isRelaxed: iap.usesRelaxedVerification
+                    params: params
                 )
             }
         } catch {
@@ -184,8 +180,7 @@ private extension TunnelContext {
         of profile: Profile,
         iapManager: IAPManager,
         environment: TunnelEnvironment,
-        params: ABI.AppConstants.TunnelVerificationParameters,
-        isRelaxed: Bool
+        params: ABI.AppConstants.TunnelVerificationParameters
     ) async {
         var attempts = params.attempts
         while true {
@@ -196,17 +191,15 @@ private extension TunnelContext {
                 await iapManager.reloadReceipt()
                 try iapManager.verify(profile)
             } catch {
-                if isRelaxed {
-                    // Mitigate the StoreKit inability to report errors, sometimes it
-                    // would just return empty products, e.g. on network failure. In those
-                    // cases, retry a few times before failing
-                    if attempts > 0 {
-                        attempts -= 1
-                        let products = iapManager.purchasedProducts
-                        pspLog(.iap, .error, "Verification failed for profile \(profile.id), next attempt in \(params.retryInterval) seconds... (remaining: \(attempts), products: \(products))")
-                        try? await Task.sleep(interval: params.retryInterval)
-                        continue
-                    }
+                // Mitigate the StoreKit inability to report errors, sometimes it
+                // would just return empty products, e.g. on network failure. In those
+                // cases, retry a few times before failing
+                if attempts > 0 {
+                    attempts -= 1
+                    let products = iapManager.purchasedProducts
+                    pspLog(.iap, .error, "Verification failed for profile \(profile.id), next attempt in \(params.retryInterval) seconds... (remaining: \(attempts), products: \(products))")
+                    try? await Task.sleep(interval: params.retryInterval)
+                    continue
                 }
 
                 let errorCode: ABI.AppErrorCode = .ineligibleProfile

--- a/app-apple/Sources/TunnelLibrary/TunnelContext.swift
+++ b/app-apple/Sources/TunnelLibrary/TunnelContext.swift
@@ -23,22 +23,22 @@ public final class TunnelContext: TunnelContextProtocol {
     }
 
     private var backend: TunnelBackendProtocol?
+    private let originalProfile: Profile
     private let environment: TunnelEnvironment
     private let iap: IAP?
-    private let originalProfile: Profile
 
     private var verifierSubscription: Task<Void, Error>?
 
     public init(
         backend: TunnelBackendProtocol,
+        originalProfile: Profile,
         environment: TunnelEnvironment,
-        iap: IAP?,
-        originalProfile: Profile
+        iap: IAP?
     ) {
         self.backend = backend
+        self.originalProfile = originalProfile
         self.environment = environment
         self.iap = iap
-        self.originalProfile = originalProfile
 
         // Disable if skips purchases
         if let iap {
@@ -186,6 +186,8 @@ private extension TunnelContext {
         while true {
             guard let backend else { return }
             guard !Task.isCancelled else { return }
+
+            // Perform periodic verification
             do {
                 pspLog(.iap, .info, "Verify profile, requires: \(profile.features)")
                 await iapManager.reloadReceipt()
@@ -193,7 +195,7 @@ private extension TunnelContext {
             } catch {
                 // Mitigate the StoreKit inability to report errors, sometimes it
                 // would just return empty products, e.g. on network failure. In those
-                // cases, retry a few times before failing
+                // cases, retry a few times before failing.
                 if attempts > 0 {
                     attempts -= 1
                     let products = iapManager.purchasedProducts
@@ -212,6 +214,7 @@ private extension TunnelContext {
                 return
             }
 
+            // Retry in a while
             pspLog(.iap, .info, "Will verify profile again in \(params.interval) seconds...")
             try? await Task.sleep(interval: params.interval)
 


### PR DESCRIPTION
Fall back to Swift on unsupported implementations:

- Provider modules
- Otherwise undecodable profiles (e.g. legacy JSON formats)

Some refactors:

- Perform some diligent cleanup in TunnelContext initializer to keep the two runtimes clear-cut and independent
- Go back to the `async` version of startTunnel(), with a forced Sendable on NSObject to work around the annoying Apple compile issues
- Assume relaxed verification by now