### PR TITLE
Core: Require more flags to enable Zig VPN

### DIFF
--- a/app-android/app/src/main/kotlin/com/algoritmico/passepartout/models/ConfigFlag.kt
+++ b/app-android/app/src/main/kotlin/com/algoritmico/passepartout/models/ConfigFlag.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.Serializable
 /**
  * 
  *
- * Values: appNotWorking,unknown,zigRuntime
+ * Values: appNotWorking,unknown,zigOpenVPN,zigRuntime,zigWireGuard
  */
 @Serializable
 enum class ConfigFlag(val value: kotlin.String) {
@@ -42,8 +42,14 @@ enum class ConfigFlag(val value: kotlin.String) {
     @SerialName(value = "unknown")
     unknown("unknown"),
 
+    @SerialName(value = "zigOpenVPN")
+    zigOpenVPN("zigOpenVPN"),
+
     @SerialName(value = "zigRuntime")
-    zigRuntime("zigRuntime");
+    zigRuntime("zigRuntime"),
+
+    @SerialName(value = "zigWireGuard")
+    zigWireGuard("zigWireGuard");
 
     /**
      * Override [toString()] to avoid using the enum variable name as the value, and instead use
@@ -71,5 +77,4 @@ enum class ConfigFlag(val value: kotlin.String) {
         }
     }
 }
-
 

--- a/app-apple/Passepartout/App/Context/test-bundle.json
+++ b/app-apple/Passepartout/App/Context/test-bundle.json
@@ -2,6 +2,12 @@
     "zigRuntime": {
         "rate": 100
     },
+    "zigOpenVPN": {
+        "rate": 100
+    },
+    "zigWireGuard": {
+        "rate": 100
+    },
     "newProfileEncoding": {
         "rate": 100
     },

--- a/app-apple/Passepartout/Tunnel/TunnelContext+Production.swift
+++ b/app-apple/Passepartout/Tunnel/TunnelContext+Production.swift
@@ -32,7 +32,8 @@ extension TunnelContext {
                         preferences: preferences,
                         cachesURL: cachesURL
                     )
-                } catch RuntimeError.unsupportedProviders {
+                } catch RuntimeError.unsupportedProviders,
+                        RuntimeError.disabledModule {
                     // Fall back to Swift
                 }
             }
@@ -82,6 +83,7 @@ private extension TunnelContext {
     }
 
     enum RuntimeError: Error {
+        case disabledModule
         case unsupportedProviders
     }
 
@@ -115,6 +117,21 @@ private extension TunnelContext {
         } catch {
             pspLog(.profiles, .fault, "Unable to decode profile in Zig (legacy?): \(error)")
             throw error
+        }
+
+        switch profile.activeConnectionModule {
+        case is OpenVPNModule:
+            guard preferences.isFlagEnabled(.zigOpenVPN) else {
+                pspLog(profile.id, .profiles, .fault, "Zig/OpenVPN disabled, falling back to Swift runtime")
+                throw RuntimeError.disabledModule
+            }
+        case is WireGuardModule:
+            guard preferences.isFlagEnabled(.zigWireGuard) else {
+                pspLog(profile.id, .profiles, .fault, "Zig/WireGuard disabled, falling back to Swift runtime")
+                throw RuntimeError.disabledModule
+            }
+        default:
+            break
         }
 
         let backend = try PartoutProviderRuntime(

--- a/app-apple/Passepartout/Tunnel/TunnelContext+Production.swift
+++ b/app-apple/Passepartout/Tunnel/TunnelContext+Production.swift
@@ -119,19 +119,16 @@ private extension TunnelContext {
             throw error
         }
 
-        switch profile.activeConnectionModule {
-        case is OpenVPNModule:
-            guard preferences.isFlagEnabled(.zigOpenVPN) else {
-                pspLog(profile.id, .profiles, .fault, "Zig/OpenVPN disabled, falling back to Swift runtime")
-                throw RuntimeError.disabledModule
-            }
-        case is WireGuardModule:
-            guard preferences.isFlagEnabled(.zigWireGuard) else {
-                pspLog(profile.id, .profiles, .fault, "Zig/WireGuard disabled, falling back to Swift runtime")
-                throw RuntimeError.disabledModule
-            }
-        default:
-            break
+        let activeModules = profile.activeModules
+        if activeModules.contains(where: { $0 is OpenVPNModule }),
+           !preferences.isFlagEnabled(.zigOpenVPN) {
+            pspLog(profile.id, .profiles, .fault, "Zig/OpenVPN disabled, falling back to Swift runtime")
+            throw RuntimeError.disabledModule
+        }
+        if activeModules.contains(where: { $0 is WireGuardModule }),
+           !preferences.isFlagEnabled(.zigWireGuard) {
+            pspLog(profile.id, .profiles, .fault, "Zig/WireGuard disabled, falling back to Swift runtime")
+            throw RuntimeError.disabledModule
         }
 
         let backend = try PartoutProviderRuntime(

--- a/app-apple/Sources/AppLibrary/Observables/ConfigObservable.swift
+++ b/app-apple/Sources/AppLibrary/Observables/ConfigObservable.swift
@@ -37,7 +37,9 @@ public final class ConfigObservable {
 extension ConfigObservable {
     public var isUsingExperimentalFeatures: Bool {
         !activeFlags.isDisjoint(with: [
-            .zigRuntime
+            .zigRuntime,
+            .zigOpenVPN,
+            .zigWireGuard
         ])
     }
 }

--- a/app-apple/Sources/AppLibrary/Views/Preferences/PreferencesAdvancedView.swift
+++ b/app-apple/Sources/AppLibrary/Views/Preferences/PreferencesAdvancedView.swift
@@ -38,7 +38,9 @@ private enum ConfigFlagPreference: String, CaseIterable, Identifiable {
 
 private extension PreferencesAdvancedView {
     static let flags: [ABI.ConfigFlag] = [
-        .zigRuntime
+        .zigRuntime,
+        .zigOpenVPN,
+        .zigWireGuard
     ]
 
     var canOverride: Bool {

--- a/app-apple/Sources/CommonLibraryCore/Domain/Codegen/OpenAPIConfigFlag.swift
+++ b/app-apple/Sources/CommonLibraryCore/Domain/Codegen/OpenAPIConfigFlag.swift
@@ -10,5 +10,7 @@ import Partout
 public enum OpenAPIConfigFlag: String, Sendable, Codable, CaseIterable {
     case appNotWorking = "appNotWorking"
     case unknown = "unknown"
+    case zigOpenVPN = "zigOpenVPN"
     case zigRuntime = "zigRuntime"
+    case zigWireGuard = "zigWireGuard"
 }

--- a/scripts/openapi.yaml
+++ b/scripts/openapi.yaml
@@ -554,11 +554,15 @@ components:
       x-enum-varnames:
       - appNotWorking
       - unknown
+      - zigOpenVPN
       - zigRuntime
+      - zigWireGuard
       enum:
       - appNotWorking
       - unknown
+      - zigOpenVPN
       - zigRuntime
+      - zigWireGuard
     ConfigBundle.Config:
       type: object
       additionalProperties: false


### PR DESCRIPTION
Current .zigRuntime flag only handles no-connection profiles.