### PR TITLE
WireGuard: Add option to prefer resolved IPv6 over IPv4

### DIFF
--- a/app-apple/Sources/AppLibraryMain/Views/Modules/WireGuard/WireGuardView+Configuration.swift
+++ b/app-apple/Sources/AppLibraryMain/Views/Modules/WireGuard/WireGuardView+Configuration.swift
@@ -86,6 +86,8 @@ private extension WireGuardView.ConfigurationView {
                 inputType: .number,
                 sideAligned: true
             )
+            Toggle(Strings.Modules.Wireguard.Interface.prefersIpv6, isOn: $viewModel.prefersIPv6)
+                .themeContainerEntry(subtitle: Strings.Modules.Wireguard.Interface.PrefersIpv6.footer)
         }
     }
 
@@ -205,6 +207,8 @@ extension WireGuardView.ConfigurationView {
 
         var mtu = ""
 
+        var prefersIPv6 = false
+
         var dnsServers = ""
 
         var dnsDomains = ""
@@ -217,6 +221,7 @@ extension WireGuardView.ConfigurationView {
             privateKey = configuration.interface.privateKey
             addresses = configuration.interface.addresses.joined(separator: separator)
             mtu = configuration.interface.mtu?.description ?? ""
+            prefersIPv6 = configuration.interface.prefersIPv6 ?? false
 
             dnsServers = configuration.interface.dns?.servers.joined(separator: separator) ?? ""
             dnsDomains = configuration.interface.dns?.domains?.joined(separator: separator) ?? ""
@@ -245,6 +250,7 @@ extension WireGuardView.ConfigurationView {
             }
             configuration.interface.addresses = addresses.trimmedSplit(separator: separator)
             configuration.interface.mtu = UInt16(mtu)
+            configuration.interface.prefersIPv6 = prefersIPv6
 
             let servers = dnsServers.trimmedSplit(separator: separator)
             let domains = dnsDomains.trimmedSplit(separator: separator)

--- a/app-apple/Sources/AppStrings/Resources/de.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/de.lproj/Localizable.strings
@@ -283,6 +283,8 @@
 "modules.openvpn.tls_wrap" = "Verpackung";
 "modules.wireguard.allowed_ips" = "Zulässige IPs";
 "modules.wireguard.interface.dns.footer" = "Das Angeben leerer Server verwirft diese DNS-Einstellungen.";
+"modules.wireguard.interface.prefers_ipv6" = "IPv6 bevorzugen";
+"modules.wireguard.interface.prefers_ipv6.footer" = "Bei Peer-Hostnamen IPv6-Adressen vor IPv4 versuchen.";
 "modules.wireguard.interface" = "Schnittstelle";
 "modules.wireguard.peer.add" = "Peer hinzufügen";
 "modules.wireguard.peer.delete" = "Peer löschen";

--- a/app-apple/Sources/AppStrings/Resources/el.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/el.lproj/Localizable.strings
@@ -283,6 +283,8 @@
 "modules.openvpn.tls_wrap" = "Περίβλημα TLS";
 "modules.wireguard.allowed_ips" = "Επιτρεπόμενες IP";
 "modules.wireguard.interface.dns.footer" = "Ο καθορισμός κενών διακομιστών θα απορρίψει αυτές τις ρυθμίσεις DNS.";
+"modules.wireguard.interface.prefers_ipv6" = "Προτίμηση IPv6";
+"modules.wireguard.interface.prefers_ipv6.footer" = "Για ονόματα κεντρικών υπολογιστών ομότιμων, δοκιμάστε διευθύνσεις IPv6 πριν από IPv4.";
 "modules.wireguard.interface" = "Διασύνδεση";
 "modules.wireguard.peer.add" = "Προσθήκη ομότιμου";
 "modules.wireguard.peer.delete" = "Διαγραφή ομότιμου";

--- a/app-apple/Sources/AppStrings/Resources/en.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/en.lproj/Localizable.strings
@@ -243,6 +243,8 @@
 "modules.wireguard.private_key.generate" = "Generate new key";
 "modules.wireguard.interface" = "Interface";
 "modules.wireguard.interface.dns.footer" = "Specifying empty servers will discard these DNS settings.";
+"modules.wireguard.interface.prefers_ipv6" = "Prefer IPv6";
+"modules.wireguard.interface.prefers_ipv6.footer" = "For peer hostnames, try IPv6 addresses before IPv4.";
 "modules.wireguard.peer" = "Peer #%d";
 "modules.wireguard.peer.add" = "Add peer";
 "modules.wireguard.peer.delete" = "Delete peer";

--- a/app-apple/Sources/AppStrings/Resources/es.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/es.lproj/Localizable.strings
@@ -283,6 +283,8 @@
 "modules.openvpn.tls_wrap" = "Envolvimiento";
 "modules.wireguard.allowed_ips" = "IPs permitidas";
 "modules.wireguard.interface.dns.footer" = "Especificar servidores vacíos descartará estos ajustes de DNS.";
+"modules.wireguard.interface.prefers_ipv6" = "Preferir IPv6";
+"modules.wireguard.interface.prefers_ipv6.footer" = "Para los nombres de host de los pares, prueba las direcciones IPv6 antes que las IPv4.";
 "modules.wireguard.interface" = "Interfaz";
 "modules.wireguard.peer.add" = "Añadir par";
 "modules.wireguard.peer.delete" = "Eliminar par";

--- a/app-apple/Sources/AppStrings/Resources/fr.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/fr.lproj/Localizable.strings
@@ -283,6 +283,8 @@
 "modules.openvpn.tls_wrap" = "Emballage";
 "modules.wireguard.allowed_ips" = "IPs autorisées";
 "modules.wireguard.interface.dns.footer" = "Spécifier des serveurs vides entraînera la suppression de ces paramètres DNS.";
+"modules.wireguard.interface.prefers_ipv6" = "Préférer IPv6";
+"modules.wireguard.interface.prefers_ipv6.footer" = "Pour les noms d’hôte des pairs, essayer les adresses IPv6 avant l’IPv4.";
 "modules.wireguard.interface" = "Interface";
 "modules.wireguard.peer.add" = "Ajouter un pair";
 "modules.wireguard.peer.delete" = "Supprimer un pair";

--- a/app-apple/Sources/AppStrings/Resources/it.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/it.lproj/Localizable.strings
@@ -283,6 +283,8 @@
 "modules.openvpn.tls_wrap" = "Wrapping";
 "modules.wireguard.allowed_ips" = "IP consentiti";
 "modules.wireguard.interface.dns.footer" = "Specificare server vuoti farà scartare queste impostazioni DNS.";
+"modules.wireguard.interface.prefers_ipv6" = "Preferisci IPv6";
+"modules.wireguard.interface.prefers_ipv6.footer" = "Per i nomi host dei peer, prova gli indirizzi IPv6 prima di quelli IPv4.";
 "modules.wireguard.interface" = "Interfaccia";
 "modules.wireguard.peer.add" = "Aggiungi peer";
 "modules.wireguard.peer.delete" = "Elimina peer";

--- a/app-apple/Sources/AppStrings/Resources/nl.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/nl.lproj/Localizable.strings
@@ -283,6 +283,8 @@
 "modules.openvpn.tls_wrap" = "TLS-wrap";
 "modules.wireguard.allowed_ips" = "Toegestane IP's";
 "modules.wireguard.interface.dns.footer" = "Het opgeven van lege servers zal deze DNS-instellingen verwerpen.";
+"modules.wireguard.interface.prefers_ipv6" = "IPv6 verkiezen";
+"modules.wireguard.interface.prefers_ipv6.footer" = "Probeer voor hostnamen van peers eerst IPv6-adressen en daarna IPv4.";
 "modules.wireguard.interface" = "Interface";
 "modules.wireguard.peer.add" = "Peer toevoegen";
 "modules.wireguard.peer.delete" = "Peer verwijderen";

--- a/app-apple/Sources/AppStrings/Resources/pl.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/pl.lproj/Localizable.strings
@@ -283,6 +283,8 @@
 "modules.openvpn.tls_wrap" = "TLS";
 "modules.wireguard.allowed_ips" = "Dozwolone IP";
 "modules.wireguard.interface.dns.footer" = "Określenie pustych serwerów spowoduje odrzucenie tych ustawień DNS.";
+"modules.wireguard.interface.prefers_ipv6" = "Preferuj IPv6";
+"modules.wireguard.interface.prefers_ipv6.footer" = "Dla nazw hostów peerów najpierw wypróbuj adresy IPv6, a potem IPv4.";
 "modules.wireguard.interface" = "Interfejs";
 "modules.wireguard.peer.add" = "Dodaj peer";
 "modules.wireguard.peer.delete" = "Usuń peer";

--- a/app-apple/Sources/AppStrings/Resources/pt.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/pt.lproj/Localizable.strings
@@ -283,6 +283,8 @@
 "modules.openvpn.tls_wrap" = "Encapsulamento";
 "modules.wireguard.allowed_ips" = "IPs permitidos";
 "modules.wireguard.interface.dns.footer" = "Especificar servidores vazios irá descartar estas configurações de DNS.";
+"modules.wireguard.interface.prefers_ipv6" = "Preferir IPv6";
+"modules.wireguard.interface.prefers_ipv6.footer" = "Para nomes de host de peers, tente endereços IPv6 antes de IPv4.";
 "modules.wireguard.interface" = "Interface";
 "modules.wireguard.peer.add" = "Adicionar peer";
 "modules.wireguard.peer.delete" = "Excluir peer";

--- a/app-apple/Sources/AppStrings/Resources/ru.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/ru.lproj/Localizable.strings
@@ -283,6 +283,8 @@
 "modules.openvpn.tls_wrap" = "TLS обертка";
 "modules.wireguard.allowed_ips" = "Разрешенные IP-адреса";
 "modules.wireguard.interface.dns.footer" = "Указание пустых серверов приведёт к отклонению этих настроек DNS.";
+"modules.wireguard.interface.prefers_ipv6" = "Предпочитать IPv6";
+"modules.wireguard.interface.prefers_ipv6.footer" = "Для имён хостов узлов сначала пробовать IPv6-адреса, затем IPv4.";
 "modules.wireguard.interface" = "Интерфейс";
 "modules.wireguard.peer.add" = "Добавить узел";
 "modules.wireguard.peer.delete" = "Удалить узел";

--- a/app-apple/Sources/AppStrings/Resources/sv.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/sv.lproj/Localizable.strings
@@ -283,6 +283,8 @@
 "modules.openvpn.tls_wrap" = "TLS-omslag";
 "modules.wireguard.allowed_ips" = "Tillåtna IP";
 "modules.wireguard.interface.dns.footer" = "Att ange tomma servrar kommer att ignorera dessa DNS-inställningar.";
+"modules.wireguard.interface.prefers_ipv6" = "Föredra IPv6";
+"modules.wireguard.interface.prefers_ipv6.footer" = "För peer-värdnamn, prova IPv6-adresser före IPv4.";
 "modules.wireguard.interface" = "Gränssnitt";
 "modules.wireguard.peer.add" = "Lägg till peer";
 "modules.wireguard.peer.delete" = "Ta bort peer";

--- a/app-apple/Sources/AppStrings/Resources/uk.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/uk.lproj/Localizable.strings
@@ -283,6 +283,8 @@
 "modules.openvpn.tls_wrap" = "Інкапсуляція";
 "modules.wireguard.allowed_ips" = "Дозволені IP-адреси";
 "modules.wireguard.interface.dns.footer" = "Вказання порожніх серверів призведе до відхилення цих налаштувань DNS.";
+"modules.wireguard.interface.prefers_ipv6" = "Надавати перевагу IPv6";
+"modules.wireguard.interface.prefers_ipv6.footer" = "Для імен хостів вузлів спочатку пробувати IPv6-адреси, а потім IPv4.";
 "modules.wireguard.interface" = "Інтерфейс";
 "modules.wireguard.peer.add" = "Додати вузол";
 "modules.wireguard.peer.delete" = "Видалити вузол";

--- a/app-apple/Sources/AppStrings/Resources/zh-Hans.lproj/Localizable.strings
+++ b/app-apple/Sources/AppStrings/Resources/zh-Hans.lproj/Localizable.strings
@@ -283,6 +283,8 @@
 "modules.openvpn.tls_wrap" = "TLS 包装";
 "modules.wireguard.allowed_ips" = "允许的 IP";
 "modules.wireguard.interface.dns.footer" = "指定空服务器将丢弃这些 DNS 设置。";
+"modules.wireguard.interface.prefers_ipv6" = "优先使用 IPv6";
+"modules.wireguard.interface.prefers_ipv6.footer" = "对于对等端主机名，先尝试 IPv6 地址，再尝试 IPv4。";
 "modules.wireguard.interface" = "接口";
 "modules.wireguard.peer.add" = "添加对等端";
 "modules.wireguard.peer.delete" = "删除对等端";

--- a/app-apple/Sources/AppStrings/SwiftGen+Strings.swift
+++ b/app-apple/Sources/AppStrings/SwiftGen+Strings.swift
@@ -849,9 +849,15 @@ public enum Strings {
       /// Pre-shared key
       public static let presharedKey = Strings.tr("Localizable", "modules.wireguard.preshared_key", fallback: "Pre-shared key")
       public enum Interface {
+        /// Prefer IPv6
+        public static let prefersIpv6 = Strings.tr("Localizable", "modules.wireguard.interface.prefers_ipv6", fallback: "Prefer IPv6")
         public enum Dns {
           /// Specifying empty servers will discard these DNS settings.
           public static let footer = Strings.tr("Localizable", "modules.wireguard.interface.dns.footer", fallback: "Specifying empty servers will discard these DNS settings.")
+        }
+        public enum PrefersIpv6 {
+          /// For peer hostnames, try IPv6 addresses before IPv4.
+          public static let footer = Strings.tr("Localizable", "modules.wireguard.interface.prefers_ipv6.footer", fallback: "For peer hostnames, try IPv6 addresses before IPv4.")
         }
       }
       public enum Peer {

--- a/app-apple/Tests/AppLibraryMainTests/WireGuardViewModelTests.swift
+++ b/app-apple/Tests/AppLibraryMainTests/WireGuardViewModelTests.swift
@@ -9,6 +9,28 @@ import Testing
 @MainActor
 struct WireGuardViewModelTests {
     @Test
+    func givenNilPrefersIPv6_whenLoad_thenDefaultsToFalse() {
+        let configuration = WireGuard.Configuration.Builder(privateKey: "")
+        var sut = WireGuardView.ConfigurationView.ViewModel()
+
+        sut.load(from: configuration)
+
+        #expect(!sut.prefersIPv6)
+    }
+
+    @Test
+    func givenPrefersIPv6_whenSave_thenUpdatesLocalInterface() {
+        let configuration = WireGuard.Configuration.Builder(privateKey: "")
+        let draft = ModuleDraft(module: WireGuardModule.Builder(configurationBuilder: configuration))
+        var sut = WireGuardView.ConfigurationView.ViewModel()
+        sut.prefersIPv6 = true
+
+        sut.save(to: draft, fallback: configuration)
+
+        #expect(draft.module.configurationBuilder?.interface.prefersIPv6 == true)
+    }
+
+    @Test
     func givenIPv6Endpoint_whenLoadAndSave_thenPreservesSquareBrackets() throws {
         let publicKey = "peer"
         var peer = WireGuard.RemoteInterface.Builder(publicKey: publicKey)


### PR DESCRIPTION
For hostname-based peers, i.e., the ones resolved via DNS, let the user choose whether to prefer resolved IPv6 addresses when available. Default behavior picks IPv4 when both IPv4 and IPv6 entries exist.

IP endpoints are not affected by this.

Fixes #1887 