### PR TITLE
WireGuard: Fix encoding before feeding to tunnel

### DIFF
--- a/app-apple/Passepartout/Tunnel/TunnelContext+Production.swift
+++ b/app-apple/Passepartout/Tunnel/TunnelContext+Production.swift
@@ -160,9 +160,19 @@ private extension TunnelContext {
             localMapper: logFormatter.localMapper
         )
 
+        // Clean up residual Swift/Zig mismatches
+        var builder = profile.builder()
+        builder.modules = try builder.modules.map {
+            if let wg = $0 as? WireGuardModule {
+                return try wg.builder().build()
+            }
+            return $0
+        }
+        let normalizedProfile = try builder.build()
+
         let backend = try PartoutProviderRuntime(
             provider: neProvider,
-            profile: profile,
+            profile: normalizedProfile,
             options: .init(
                 dnsFallbackServers: appConfiguration.constants.tunnel.dnsFallbackServers,
                 logsSnapshots: false
@@ -177,7 +187,7 @@ private extension TunnelContext {
 
         return ProductionRuntime(
             backend: backend,
-            originalProfile: profile,
+            originalProfile: normalizedProfile,
             environment: backend.environment
         )
     }


### PR DESCRIPTION
Old Swift encoders may end up with an empty non-null preSharedKey, which the Zig decoder doesn't tolerate.